### PR TITLE
[Feat#28] 회의 참여자 조회 기능 개발

### DIFF
--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
@@ -1,18 +1,17 @@
 package org.dnd.timeet.meeting.application;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.dnd.timeet.common.exception.BadRequestError;
 import org.dnd.timeet.common.exception.NotFoundError;
-
 import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.domain.MeetingRepository;
-
-import org.dnd.timeet.participant.domain.Participant;
-import org.dnd.timeet.participant.domain.ParticipantRepository;
 import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
 import org.dnd.timeet.member.domain.Member;
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
+import org.dnd.timeet.participant.domain.Participant;
+import org.dnd.timeet.participant.domain.ParticipantRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -76,6 +75,17 @@ public class MeetingService {
             meeting.assignNewHostRandomly();
         }
 
+    }
+
+    @Transactional(readOnly = true)
+    public List<Member> getMeetingMembers(Long meetingId) {
+        Meeting meeting = meetingRepository.findByIdWithParticipantsAndMembers(meetingId)
+            .orElseThrow(() -> new NotFoundError(NotFoundError.ErrorCode.RESOURCE_NOT_FOUND,
+                Collections.singletonMap("MeetingId", "Meeting not found")));
+
+        return meeting.getParticipants().stream()
+            .map(Participant::getMember)
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
@@ -14,6 +14,7 @@ import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
 import org.dnd.timeet.meeting.dto.MeetingCreateResponse;
 import org.dnd.timeet.meeting.dto.MeetingInfoResponse;
+import org.dnd.timeet.member.dto.MemberInfoListResponse;
 import org.dnd.timeet.member.dto.MemberInfoResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -66,13 +67,16 @@ public class MeetingController {
 
     @GetMapping("/{meeting-id}/users")
     @Operation(summary = "회의 참가자 조회", description = "회의에 참가한 사용자를 조회한다.")
-    public ResponseEntity getMeetingMembers(@PathVariable("meeting-id") Long meetingId) {
-        List<MemberInfoResponse> memberInfoReponseList = meetingService.getMeetingMembers(meetingId)
+    public ResponseEntity<ApiResult<MemberInfoListResponse>> getMeetingMembers(
+        @PathVariable("meeting-id") Long meetingId) {
+        List<MemberInfoResponse> memberInfoList = meetingService.getMeetingMembers(meetingId)
             .stream()
             .map(MemberInfoResponse::from)
             .collect(Collectors.toList());
 
-        return ResponseEntity.ok(ApiUtils.success(memberInfoReponseList));
+        MemberInfoListResponse memberInfoListResponse = new MemberInfoListResponse(memberInfoList);
+
+        return ResponseEntity.ok(ApiUtils.success(memberInfoListResponse));
     }
 
 

--- a/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
@@ -3,6 +3,8 @@ package org.dnd.timeet.meeting.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.dnd.timeet.common.security.CustomUserDetails;
 import org.dnd.timeet.common.utils.ApiUtils;
@@ -12,6 +14,7 @@ import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
 import org.dnd.timeet.meeting.dto.MeetingCreateResponse;
 import org.dnd.timeet.meeting.dto.MeetingInfoResponse;
+import org.dnd.timeet.member.dto.MemberInfoResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -60,5 +63,17 @@ public class MeetingController {
 
         return ResponseEntity.ok(ApiUtils.success(meetingInfoResponse));
     }
+
+    @GetMapping("/{meeting-id}/users")
+    @Operation(summary = "회의 참가자 조회", description = "회의에 참가한 사용자를 조회한다.")
+    public ResponseEntity getMeetingMembers(@PathVariable("meeting-id") Long meetingId) {
+        List<MemberInfoResponse> memberInfoReponseList = meetingService.getMeetingMembers(meetingId)
+            .stream()
+            .map(MemberInfoResponse::from)
+            .collect(Collectors.toList());
+
+        return ResponseEntity.ok(ApiUtils.success(memberInfoReponseList));
+    }
+
 
 }

--- a/src/main/java/org/dnd/timeet/meeting/domain/MeetingRepository.java
+++ b/src/main/java/org/dnd/timeet/meeting/domain/MeetingRepository.java
@@ -1,8 +1,13 @@
 package org.dnd.timeet.meeting.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
-//    Optional<Timer> findByUserId(Long id);
+    @Query("select m from Meeting m join fetch m.participants p join fetch p.member where m.id = :meetingId")
+    Optional<Meeting> findByIdWithParticipantsAndMembers(@Param("meetingId") Long meetingId);
+
 }

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.dnd.timeet.meeting.domain.Meeting;
-import org.dnd.timeet.timer.domain.Timer;
-import org.dnd.timeet.timer.domain.TimerStatus;
 
 @Schema(description = "회의 정보 응답")
 @Getter
@@ -19,7 +17,7 @@ public class MeetingInfoResponse {
     @Schema(description = "회의 제목", example = "2차 회의")
     private String title;
 
-    @Schema(description = "회의 목", example = "2개의 사안 모두 해결하기")
+    @Schema(description = "회의 목표", example = "2개의 사안 모두 해결하기")
     private String description;
 
     @Builder

--- a/src/main/java/org/dnd/timeet/member/dto/MemberInfoListResponse.java
+++ b/src/main/java/org/dnd/timeet/member/dto/MemberInfoListResponse.java
@@ -1,0 +1,18 @@
+package org.dnd.timeet.member.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberInfoListResponse {
+
+
+    private List<MemberInfoResponse> members;
+
+
+    public MemberInfoListResponse(List<MemberInfoResponse> members) {
+        this.members = members;
+    }
+}

--- a/src/main/java/org/dnd/timeet/member/dto/MemberInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/member/dto/MemberInfoResponse.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.dnd.timeet.member.domain.Member;
-import org.dnd.timeet.member.domain.MemberRole;
 
 @Getter
 @Setter
@@ -13,22 +12,18 @@ public class MemberInfoResponse {
     @Schema(description = "사용자 id", nullable = false, example = "12")
     private long id;
     @Schema(description = "사용자 이름", nullable = false, example = "green12")
-    private String username;
-    @Schema(description = "사용자 역할", nullable = false, example = "ROLE_USER")
-    private MemberRole role;
+    private String name;
 
 
-    public MemberInfoResponse(long id, String username, MemberRole role) {
+    public MemberInfoResponse(long id, String name) {
         this.id = id;
-        this.username = username;
-        this.role = role;
+        this.name = name;
     }
 
     public static MemberInfoResponse from(Member member) {
         return new MemberInfoResponse(
             member.getId(),
-            member.getName(),
-            member.getRole()
+            member.getName()
         );
     }
 }


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #28 

resolved: #28 

### 🛠 개발 기능
- 회의 참여자 조회 기능을 개발하였습니다.
- MeetingInfoResponse 내 오타를 수정하였습니다.

### 🧩 해결 방법
- 회의 참여에 필요한 컨트롤러, 서비스, JPA 쿼리를 작성하였습니다.

### 🔍 리뷰 포인트
- 현재 Member와 Participant가 LAZY 관계로 설정되어 있어, 서비스 단에서 Member 조회 시 `LazyInitializationException` 이 발생합니다.
- Member와 Participant의 관계를 EAGER로 설정하는 방법은 Meeting을 조회할 때마다 매번 Member까지 조회를 해야해서 **성능에 부정적인 영향**을 미칠 수 있다고 판단하였습니다.
- 따라서 Meeting을 조회할 때 Participant와 Member도 함께 조회할 수 있도록 **join fetch**를 작성하였습니다.
- 하지만 JPA 쿼리를 직접 작성하는 방식은 개발 복잡도가 올라가고, 의도치 않은 동작을 수행할 수 있다는 단점이 존재할 수 있을 것 같습니다.
- 해당 문제해결 방법이 맞는지, 잘못된 내용이나 조금 더 개선할 부분이 있을지 리뷰 부탁드려요! 😄



<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
