### PR TITLE
[Feat#26] 회의 리포트 생성 및 회의 종료 기능을 추가

### DIFF
--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaReportInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaReportInfoResponse.java
@@ -1,0 +1,44 @@
+package org.dnd.timeet.agenda.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.dnd.timeet.agenda.domain.Agenda;
+import org.dnd.timeet.common.utils.TimeUtils;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Schema(description = "회의 정보 응답 (리포트 생성용)")
+@Getter
+@Setter
+public class AgendaReportInfoResponse {
+
+    @Schema(description = "안건 id", example = "12")
+    private Long agendaId;
+
+    @Schema(description = "안건 제목", example = "안건1")
+    private String title;
+
+    @Schema(description = "소요 시간 차이 (실제 소요 시간 - 예상 소요 시간)", example = "01:30")
+    @DateTimeFormat(pattern = "HH:mm")
+    private Duration diff;
+
+
+    @Builder
+    public AgendaReportInfoResponse(Long agendaId, String title,
+                                    Duration diff) {
+        this.agendaId = agendaId;
+        this.title = title;
+        this.diff = diff;
+    }
+
+
+    public static AgendaReportInfoResponse from(Agenda agenda) { // 매개변수로부터 객체를 생성하는 팩토리 메서드
+        return AgendaReportInfoResponse.builder()
+            .agendaId(agenda.getId())
+            .title(agenda.getTitle())
+            .diff(TimeUtils.calculateTimeDiff(agenda.getEstimatedDuration(), agenda.getActualDuration()))
+            .build();
+    }
+}

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaReportInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaReportInfoResponse.java
@@ -1,13 +1,13 @@
 package org.dnd.timeet.agenda.dto;
 
+import static org.dnd.timeet.common.utils.TimeUtils.calculateTimeDiff;
+import static org.dnd.timeet.common.utils.TimeUtils.formatDuration;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.Duration;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.dnd.timeet.agenda.domain.Agenda;
-import org.dnd.timeet.common.utils.TimeUtils;
-import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "회의 정보 응답 (리포트 생성용)")
 @Getter
@@ -20,14 +20,13 @@ public class AgendaReportInfoResponse {
     @Schema(description = "안건 제목", example = "안건1")
     private String title;
 
-    @Schema(description = "소요 시간 차이 (실제 소요 시간 - 예상 소요 시간)", example = "01:30")
-    @DateTimeFormat(pattern = "HH:mm")
-    private Duration diff;
+    @Schema(description = "소요 시간 차이 (실제 소요 시간 - 예상 소요 시간)", example = "+01:30")
+    private String diff;
 
 
     @Builder
     public AgendaReportInfoResponse(Long agendaId, String title,
-                                    Duration diff) {
+                                    String diff) {
         this.agendaId = agendaId;
         this.title = title;
         this.diff = diff;
@@ -38,7 +37,7 @@ public class AgendaReportInfoResponse {
         return AgendaReportInfoResponse.builder()
             .agendaId(agenda.getId())
             .title(agenda.getTitle())
-            .diff(TimeUtils.calculateTimeDiff(agenda.getEstimatedDuration(), agenda.getActualDuration()))
+            .diff(formatDuration(calculateTimeDiff(agenda.getActualDuration(), agenda.getEstimatedDuration())))
             .build();
     }
 }

--- a/src/main/java/org/dnd/timeet/common/utils/TimeUtils.java
+++ b/src/main/java/org/dnd/timeet/common/utils/TimeUtils.java
@@ -1,0 +1,19 @@
+package org.dnd.timeet.common.utils;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.Collections;
+import org.dnd.timeet.common.exception.InternalServerError;
+
+public class TimeUtils {
+
+    public static Duration calculateTimeDiff(LocalTime totalEstimatedDuration, LocalTime totalActualDuration) {
+        if (totalEstimatedDuration == null || totalActualDuration == null) {
+            throw new InternalServerError(InternalServerError.ErrorCode.INTERNAL_SERVER_ERROR,
+                Collections.singletonMap("LocalTime", "LocalTime EstimatedDuration or ActualDuration is null"));
+        }
+
+        return Duration.between(totalEstimatedDuration, totalActualDuration);
+    }
+
+}

--- a/src/main/java/org/dnd/timeet/common/utils/TimeUtils.java
+++ b/src/main/java/org/dnd/timeet/common/utils/TimeUtils.java
@@ -7,13 +7,28 @@ import org.dnd.timeet.common.exception.InternalServerError;
 
 public class TimeUtils {
 
-    public static Duration calculateTimeDiff(LocalTime totalEstimatedDuration, LocalTime totalActualDuration) {
-        if (totalEstimatedDuration == null || totalActualDuration == null) {
+    public static Duration calculateTimeDiff(LocalTime ActualDuration, LocalTime EstimatedDuration) {
+
+        if (ActualDuration == null) {
             throw new InternalServerError(InternalServerError.ErrorCode.INTERNAL_SERVER_ERROR,
-                Collections.singletonMap("LocalTime", "LocalTime EstimatedDuration or ActualDuration is null"));
+                Collections.singletonMap("LocalTime", "ActualDuration is null"));
+        }
+        if (EstimatedDuration == null) {
+            throw new InternalServerError(InternalServerError.ErrorCode.INTERNAL_SERVER_ERROR,
+                Collections.singletonMap("LocalTime", "EstimatedDuration is null"));
         }
 
-        return Duration.between(totalEstimatedDuration, totalActualDuration);
+        return Duration.between(EstimatedDuration, ActualDuration);
+    }
+
+    public static String formatDuration(Duration duration) {
+        long hours = duration.abs().toHours();
+        long minutes = duration.minusHours(duration.toHours()).abs().toMinutes();
+        String prefix = "+";
+        if (duration.isNegative()) {
+            prefix = "-";
+        }
+        return prefix + String.format("%02d:%02d", hours, minutes);
     }
 
 }

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
@@ -42,6 +42,14 @@ public class MeetingService {
         return meeting;
     }
 
+    public void endMeeting(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+            .orElseThrow(() -> new NotFoundError(NotFoundError.ErrorCode.RESOURCE_NOT_FOUND,
+                Collections.singletonMap("MeetingId", "Meeting not found")));
+
+        meeting.endMeeting();
+    }
+
     public Meeting addParticipantToMeeting(Long meetingId, Member member) {
         Meeting meeting = meetingRepository.findById(meetingId)
             .orElseThrow(() -> new NotFoundError(NotFoundError.ErrorCode.RESOURCE_NOT_FOUND,

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
@@ -1,6 +1,8 @@
 package org.dnd.timeet.meeting.application;
 
-import java.time.LocalTime;
+import static org.dnd.timeet.common.utils.TimeUtils.calculateTimeDiff;
+import static org.dnd.timeet.common.utils.TimeUtils.formatDuration;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -10,9 +12,7 @@ import org.dnd.timeet.agenda.domain.AgendaStatus;
 import org.dnd.timeet.agenda.domain.AgendaType;
 import org.dnd.timeet.agenda.dto.AgendaReportInfoResponse;
 import org.dnd.timeet.common.exception.BadRequestError;
-import org.dnd.timeet.common.exception.InternalServerError;
 import org.dnd.timeet.common.exception.NotFoundError;
-import org.dnd.timeet.common.utils.TimeUtils;
 import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.domain.MeetingRepository;
 import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
@@ -80,23 +80,13 @@ public class MeetingService {
 
         return MeetingReportInfoResponse.builder()
             .totalDiff(
-                TimeUtils.calculateTimeDiff(meeting.getTotalEstimatedDuration(), meeting.getTotalActualDuration()))
+                formatDuration(
+                    calculateTimeDiff(meeting.getTotalActualDuration(), meeting.getTotalEstimatedDuration())))
             .agendas(agendaReportInfoResponses)
             .memos("회의록입니다.")
             .build();
 
     }
-
-    private LocalTime calculateTotalDiff(LocalTime totalEstimatedDuration, LocalTime totalActualDuration) {
-        if (totalEstimatedDuration == null || totalActualDuration == null) {
-            throw new InternalServerError(InternalServerError.ErrorCode.INTERNAL_SERVER_ERROR,
-                Collections.singletonMap("Meeting", "Meeting totalEstimatedDuration or totalActualDuration is null"));
-        }
-
-        return totalEstimatedDuration.minusHours(totalActualDuration.getHour())
-            .minusMinutes(totalActualDuration.getMinute());
-    }
-
 
     @Transactional(readOnly = true)
     public Meeting findById(Long id) {

--- a/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
@@ -21,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,6 +59,16 @@ public class MeetingController {
         return ResponseEntity.ok(ApiUtils.success(meetingCreateResponse));
     }
 
+    @PatchMapping("/{meeting-id}/end")
+    @Operation(summary = "회의 종료", description = "회의를 종료한다.")
+    public ResponseEntity<ApiResult<MeetingReportInfoResponse>> closeMeeting(
+        @PathVariable("meeting-id") Long meetingId) {
+        meetingService.endMeeting(meetingId);
+        MeetingReportInfoResponse meetingReportInfoResponse = meetingService.createReport(meetingId);
+
+        return ResponseEntity.ok(ApiUtils.success(meetingReportInfoResponse));
+    }
+
     @GetMapping("/{id}")
     @Operation(summary = "단일 회의 조회", description = "지정된 id에 해당하는 회의를 조회한다.")
     public ResponseEntity<ApiResult<MeetingInfoResponse>> getTimerById(@PathVariable("id") Long meetingId) {
@@ -75,6 +86,7 @@ public class MeetingController {
 
         return ResponseEntity.ok(ApiUtils.success(meetingReportInfoResponse));
     }
+
     @DeleteMapping("/{meeting-id}")
     @Operation(summary = "회의 삭제", description = "지정된 id에 해당하는 회의를 삭제한다.")
     public ResponseEntity deleteMeeting(@PathVariable("meeting-id") Long meetingId) {

--- a/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
@@ -15,6 +15,7 @@ import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
 import org.dnd.timeet.meeting.dto.MeetingCreateResponse;
 import org.dnd.timeet.meeting.dto.MeetingInfoResponse;
 import org.dnd.timeet.meeting.dto.MeetingReportInfoResponse;
+import org.dnd.timeet.meeting.dto.MeetingReportResponse;
 import org.dnd.timeet.member.dto.MemberInfoListResponse;
 import org.dnd.timeet.member.dto.MemberInfoResponse;
 import org.springframework.http.ResponseEntity;
@@ -61,12 +62,13 @@ public class MeetingController {
 
     @PatchMapping("/{meeting-id}/end")
     @Operation(summary = "회의 종료", description = "회의를 종료한다.")
-    public ResponseEntity<ApiResult<MeetingReportInfoResponse>> closeMeeting(
+    public ResponseEntity<ApiResult<MeetingReportResponse>> closeMeeting(
         @PathVariable("meeting-id") Long meetingId) {
         meetingService.endMeeting(meetingId);
         MeetingReportInfoResponse meetingReportInfoResponse = meetingService.createReport(meetingId);
+        MeetingReportResponse meetingReportResponse = new MeetingReportResponse(meetingReportInfoResponse);
 
-        return ResponseEntity.ok(ApiUtils.success(meetingReportInfoResponse));
+        return ResponseEntity.ok(ApiUtils.success(meetingReportResponse));
     }
 
     @GetMapping("/{id}")
@@ -80,11 +82,13 @@ public class MeetingController {
 
     @GetMapping("{meeting-id}/report")
     @Operation(summary = "회의 리포트 조회", description = "회의 리포트를 조회한다.")
-    public ResponseEntity<ApiResult<MeetingReportInfoResponse>> getMeetingReport(
+    public ResponseEntity<ApiResult<MeetingReportResponse>> getMeetingReport(
         @PathVariable("meeting-id") Long meetingId) {
         MeetingReportInfoResponse meetingReportInfoResponse = meetingService.createReport(meetingId);
 
-        return ResponseEntity.ok(ApiUtils.success(meetingReportInfoResponse));
+        MeetingReportResponse meetingReportResponse = new MeetingReportResponse(meetingReportInfoResponse);
+
+        return ResponseEntity.ok(ApiUtils.success(meetingReportResponse));
     }
 
     @DeleteMapping("/{meeting-id}")

--- a/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
@@ -12,6 +12,7 @@ import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
 import org.dnd.timeet.meeting.dto.MeetingCreateResponse;
 import org.dnd.timeet.meeting.dto.MeetingInfoResponse;
+import org.dnd.timeet.meeting.dto.MeetingReportInfoResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -61,4 +62,12 @@ public class MeetingController {
         return ResponseEntity.ok(ApiUtils.success(meetingInfoResponse));
     }
 
+    @GetMapping("{meeting-id}/report")
+    @Operation(summary = "회의 리포트 조회", description = "회의 리포트를 조회한다.")
+    public ResponseEntity<ApiResult<MeetingReportInfoResponse>> getMeetingReport(
+        @PathVariable("meeting-id") Long meetingId) {
+        MeetingReportInfoResponse meetingReportInfoResponse = meetingService.createReport(meetingId);
+
+        return ResponseEntity.ok(ApiUtils.success(meetingReportInfoResponse));
+    }
 }

--- a/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
+++ b/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
@@ -101,10 +101,16 @@ public class Meeting extends AuditableEntity {
             throw new BadRequestError(ErrorCode.WRONG_REQUEST_TRANSMISSION,
                 Collections.singletonMap("MeetingId", "Meeting already completed"));
         }
-        
+
         this.status = MeetingStatus.COMPLETED;
 
         long durationInSeconds = Duration.between(startTime, endTime).getSeconds();
+
+        if (durationInSeconds > 24 * 3600) { // 하루를 초과하는 경우
+            throw new BadRequestError(ErrorCode.WRONG_REQUEST_TRANSMISSION,
+                Collections.singletonMap("Meeting", "Meeting duration exceeds one day"));
+        }
+
         this.totalActualDuration = LocalTime.ofSecondOfDay(durationInSeconds);
     }
 

--- a/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
+++ b/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.dnd.timeet.common.domain.AuditableEntity;
 import org.dnd.timeet.common.exception.BadRequestError;
+import org.dnd.timeet.common.exception.BadRequestError.ErrorCode;
 import org.dnd.timeet.member.domain.Member;
 import org.dnd.timeet.participant.domain.Participant;
 import org.hibernate.annotations.Where;
@@ -78,7 +79,7 @@ public class Meeting extends AuditableEntity {
 
     @Builder
     public Meeting(Member hostMember, String title, LocalDateTime startTime, LocalTime totalEstimatedDuration,
-        String location, String description, Integer imgNum) {
+                   String location, String description, Integer imgNum) {
         this.hostMember = hostMember;
         this.title = title;
         this.startTime = startTime;
@@ -95,6 +96,12 @@ public class Meeting extends AuditableEntity {
 
     public void endMeeting() {
         this.endTime = LocalDateTime.now();
+
+        if (this.status == MeetingStatus.COMPLETED) {
+            throw new BadRequestError(ErrorCode.WRONG_REQUEST_TRANSMISSION,
+                Collections.singletonMap("MeetingId", "Meeting already completed"));
+        }
+        
         this.status = MeetingStatus.COMPLETED;
 
         long durationInSeconds = Duration.between(startTime, endTime).getSeconds();

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingReportInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingReportInfoResponse.java
@@ -1,32 +1,29 @@
 package org.dnd.timeet.meeting.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.Duration;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.dnd.timeet.agenda.dto.AgendaReportInfoResponse;
-import org.springframework.format.annotation.DateTimeFormat;
 
 @Schema(description = "회의 리포트 응답")
 @Getter
 @Setter
 public class MeetingReportInfoResponse {
 
-    @Schema(description = "소요 시간 차이 (실제 소요 시간 - 예상 소요 시간)", example = "01:30")
-    @DateTimeFormat(pattern = "HH:mm")
-    private Duration totalDiff;
+    @Schema(description = "소요 시간 차이 (실제 소요 시간 - 예상 소요 시간)", example = "+01:30")
+    private String totalDiff;
 
     @Schema(description = "안건 정보")
     private List<AgendaReportInfoResponse> agendas;
 
-    //TODO: 회의 메모 추가 예정
-    @Schema(description = "회의 메모", example = "회의 내용 메모 (추가 예정)")
+    //TODO: 회의 메모 추가
+    @Schema(description = "회의 메모", example = "회의 내용 메모")
     private String memos;
 
     @Builder
-    public MeetingReportInfoResponse(Duration totalDiff, List<AgendaReportInfoResponse> agendas, String memos) {
+    public MeetingReportInfoResponse(String totalDiff, List<AgendaReportInfoResponse> agendas, String memos) {
         this.totalDiff = totalDiff;
         this.agendas = agendas;
         this.memos = memos;

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingReportInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingReportInfoResponse.java
@@ -1,0 +1,34 @@
+package org.dnd.timeet.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.dnd.timeet.agenda.dto.AgendaReportInfoResponse;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Schema(description = "회의 리포트 응답")
+@Getter
+@Setter
+public class MeetingReportInfoResponse {
+
+    @Schema(description = "소요 시간 차이 (실제 소요 시간 - 예상 소요 시간)", example = "01:30")
+    @DateTimeFormat(pattern = "HH:mm")
+    private Duration totalDiff;
+
+    @Schema(description = "안건 정보")
+    private List<AgendaReportInfoResponse> agendas;
+
+    //TODO: 회의 메모 추가 예정
+    @Schema(description = "회의 메모", example = "회의 내용 메모 (추가 예정)")
+    private String memos;
+
+    @Builder
+    public MeetingReportInfoResponse(Duration totalDiff, List<AgendaReportInfoResponse> agendas, String memos) {
+        this.totalDiff = totalDiff;
+        this.agendas = agendas;
+        this.memos = memos;
+    }
+}

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingReportResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingReportResponse.java
@@ -1,0 +1,15 @@
+package org.dnd.timeet.meeting.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MeetingReportResponse {
+
+    private MeetingReportInfoResponse report;
+
+    public MeetingReportResponse(MeetingReportInfoResponse report) {
+        this.report = report;
+    }
+}


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #26 

resolved: #26 

### 🛠 개발 기능
- 회의 리포트 생성 및 종료 기능 추가

### 🧩 해결 방법
- 회의 리포트 생성을 위한 DTO를 추가하였습니다.
- Duration 계산과 문자열 포맷 변경 위한 TimeUtil을 추가하였습니다.
- 회의 생성 엔드포인트를 개발하였습니다.
- 회의 종료 엔드포인트를 개발하였습니다. 
- 이전 미팅에서 **리포트에서 시간 차이**는 별도의 status를 두고 하기로 하였으나, **오히려 필드가 많아지고, 로직이 복잡**해져 기존의 `+HH:mm`, `-HH:mm` 방식을 채택하였습니다.
- 메모의 경우 아직 기능 구현이 되지 않았으므로, 일단은 필드를 String으로 처리하였습니다.
### 🔍 리뷰 포인트
- Timeutil에서 시간 차이를 계산하는 로직에서 잘못된 부분이 없을지 궁금해요!



<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
