### PR TITLE
[Feat#27] 회의 삭제 기능 추가

### DIFF
--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
@@ -4,15 +4,12 @@ import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.dnd.timeet.common.exception.BadRequestError;
 import org.dnd.timeet.common.exception.NotFoundError;
-
 import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.domain.MeetingRepository;
-
-import org.dnd.timeet.participant.domain.Participant;
-import org.dnd.timeet.participant.domain.ParticipantRepository;
 import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
 import org.dnd.timeet.member.domain.Member;
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
+import org.dnd.timeet.participant.domain.Participant;
+import org.dnd.timeet.participant.domain.ParticipantRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -76,6 +73,14 @@ public class MeetingService {
             meeting.assignNewHostRandomly();
         }
 
+    }
+
+    public void cancelMeeting(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+            .orElseThrow(() -> new NotFoundError(NotFoundError.ErrorCode.RESOURCE_NOT_FOUND,
+                Collections.singletonMap("MeetingId", "Meeting not found")));
+
+        meeting.cancelMeeting();
     }
 
 }

--- a/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
@@ -14,6 +14,7 @@ import org.dnd.timeet.meeting.dto.MeetingCreateResponse;
 import org.dnd.timeet.meeting.dto.MeetingInfoResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -59,6 +60,13 @@ public class MeetingController {
         MeetingInfoResponse meetingInfoResponse = MeetingInfoResponse.from(meeting);
 
         return ResponseEntity.ok(ApiUtils.success(meetingInfoResponse));
+    }
+
+    @DeleteMapping("/{meeting-id}")
+    @Operation(summary = "회의 삭제", description = "지정된 id에 해당하는 회의를 삭제한다.")
+    public ResponseEntity deleteMeeting(@PathVariable("meeting-id") Long meetingId) {
+        meetingService.cancelMeeting(meetingId);
+        return ResponseEntity.noContent().build();
     }
 
 }


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #27

resolved: #27

### 🛠 개발 기능
- 회의 삭제 기능을 추가하였습니다.

### 🧩 해결 방법
- 사전에 Meeting 도메인에 정의된 cancelMeeting 메서드를 활용하여 컨트롤러와 서비스를 작성하였습니다.
- API의 반환으로 204 NO CONTENT를 사용하였습니다.

### 🔍 리뷰 포인트
- 204 NO CONTENT를 반환하는 형식이 올바른지 확인 부탁드려요 ☺️



<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
