### PR TITLE
[Feat/#24]  안건 실시간 제어 및 갱신 API 개선

### DIFF
--- a/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
+++ b/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.dnd.timeet.agenda.domain.Agenda;
+import org.dnd.timeet.agenda.domain.AgendaAction;
 import org.dnd.timeet.agenda.domain.AgendaRepository;
 import org.dnd.timeet.agenda.dto.AgendaActionRequest;
 import org.dnd.timeet.agenda.dto.AgendaActionResponse;
@@ -55,20 +56,30 @@ public class AgendaService {
             .orElseThrow(() -> new NotFoundError(ErrorCode.RESOURCE_NOT_FOUND,
                 Collections.singletonMap("AgendaId", "Agenda not found")));
 
-        switch (actionRequest.getAction()) {
-            case "start":
+        String actionString = actionRequest.getAction().toUpperCase();
+        AgendaAction action;
+
+        try {
+            action = AgendaAction.valueOf(actionString);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestError(BadRequestError.ErrorCode.VALIDATION_FAILED,
+                Collections.singletonMap("Action", "Invalid action"));
+        }
+
+        switch (action) {
+            case START:
                 agenda.start();
                 break;
-            case "pause":
+            case PAUSE:
                 agenda.pause();
                 break;
-            case "resume":
+            case RESUME:
                 agenda.resume();
                 break;
-            case "end":
+            case END:
                 agenda.complete();
                 break;
-            case "modify":
+            case MODIFY:
                 LocalTime modifiedDuration = LocalTime.parse(actionRequest.getModifiedDuration());
                 agenda.extendDuration(DurationUtils.convertLocalTimeToDuration(modifiedDuration));
                 break;

--- a/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
+++ b/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
@@ -52,6 +52,9 @@ public class AgendaService {
                 Collections.singletonMap("AgendaId", "Agenda not found")));
 
         switch (actionRequest.getAction()) {
+            case "start":
+                agenda.start();
+                break;
             case "pause":
                 agenda.pause();
                 break;

--- a/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
+++ b/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
@@ -62,9 +62,9 @@ public class AgendaController {
      * @MessageMapping : 클라이언트에서 해당 url로 메세지를 보내면 요청을 처리한다.
      * @SendTo : 브로커에게 메세지를 보낸다.
      *  과정
-     *  1. 클라이언트에서 /app/meeting/{meetingId}/agendas/{agendaId}/action 으로 메세지를 보낸다.
+     *  1. 클라이언트에서 /app/meeting/{meeting-id}/agendas/{agenda-id}/action 으로 메세지를 보낸다.
      *  2. 핸들러가 메세지를 처리한다.
-     *  3. 서버는 그 결과를 /topic/meeting/{meetingId}/agendas/{agendaId}/status 주소로 브로커에게 보낸다.
+     *  3. 서버는 그 결과를 /topic/meeting/{meeting-id}/agendas/{agenda-id}/status 주소로 브로커에게 보낸다.
      *  4. 브로커는 해당 주소를 구독하고 있는 클라이언트에게 메세지를 전달한다.
      */
     @Operation(summary = "안건 제어 및 갱신", description = "해당 안건을 제어 및 갱신한다.")

--- a/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
+++ b/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
@@ -52,20 +52,20 @@ public class AgendaController {
         @PathVariable("meeting-id") Long meetingId) {
         List<AgendaInfoResponse> agendaInfoResponseList = agendaService.findAll(meetingId)
             .stream()
-            .map(AgendaInfoResponse::from)
+            .map(a -> new AgendaInfoResponse(a, a.calculateCurrentDuration(), a.calculateRemainingTime()))
             .collect(Collectors.toList());
 
         return ResponseEntity.ok(ApiUtils.success(agendaInfoResponseList));
     }
 
     /*
-    * @MessageMapping : 클라이언트에서 해당 url로 메세지를 보내면 요청을 처리한다.
-    * @SendTo : 브로커에게 메세지를 보낸다.
-    *  과정
-    *  1. 클라이언트에서 /app/meeting/{meetingId}/agendas/{agendaId}/action 으로 메세지를 보낸다.
-    *  2. 핸들러가 메세지를 처리한다.
-    *  3. 서버는 그 결과를 /topic/meeting/{meetingId}/agendas/{agendaId}/status 주소로 브로커에게 보낸다.
-    *  4. 브로커는 해당 주소를 구독하고 있는 클라이언트에게 메세지를 전달한다.
+     * @MessageMapping : 클라이언트에서 해당 url로 메세지를 보내면 요청을 처리한다.
+     * @SendTo : 브로커에게 메세지를 보낸다.
+     *  과정
+     *  1. 클라이언트에서 /app/meeting/{meetingId}/agendas/{agendaId}/action 으로 메세지를 보낸다.
+     *  2. 핸들러가 메세지를 처리한다.
+     *  3. 서버는 그 결과를 /topic/meeting/{meetingId}/agendas/{agendaId}/status 주소로 브로커에게 보낸다.
+     *  4. 브로커는 해당 주소를 구독하고 있는 클라이언트에게 메세지를 전달한다.
      */
     @Operation(summary = "안건 제어 및 갱신", description = "해당 안건을 제어 및 갱신한다.")
     @MessageMapping("/meeting/{meeting-id}/agendas/{agenda-id}/action")
@@ -74,8 +74,6 @@ public class AgendaController {
                                                    @DestinationVariable("agenda-id") Long agendaId,
                                                    AgendaActionRequest actionRequest) {
         // 로직 구현 (안건 상태 변경)
-        Agenda agenda = agendaService.changeAgendaStatus(meetingId, agendaId, actionRequest);
-        // 변경된 안건 상태로 응답 객체 생성 및 반환
-        return new AgendaActionResponse(agenda.getId(), agenda.getStatus());
+        return agendaService.changeAgendaStatus(meetingId, agendaId, actionRequest);
     }
 }

--- a/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
+++ b/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
@@ -58,15 +58,15 @@ public class AgendaController {
         return ResponseEntity.ok(ApiUtils.success(agendaInfoResponseList));
     }
 
-//    /*
-//    * @MessageMapping : 클라이언트에서 해당 url로 메세지를 보내면 요청을 처리한다.
-//    * @SendTo : 브로커에게 메세지를 보낸다.
-//    *  과정
-//    *  1. 클라이언트에서 /app/meeting/{meetingId}/agendas/{agendaId}/action 으로 메세지를 보낸다.
-//    *  2. 핸들러가 메세지를 처리한다.
-//    *  3. 서버는 그 결과를 /topic/meeting/{meetingId}/agendas/{agendaId}/status 주소로 브로커에게 보낸다.
-//    *  4. 브로커는 해당 주소를 구독하고 있는 클라이언트에게 메세지를 전달한다.
-//     */
+    /*
+    * @MessageMapping : 클라이언트에서 해당 url로 메세지를 보내면 요청을 처리한다.
+    * @SendTo : 브로커에게 메세지를 보낸다.
+    *  과정
+    *  1. 클라이언트에서 /app/meeting/{meetingId}/agendas/{agendaId}/action 으로 메세지를 보낸다.
+    *  2. 핸들러가 메세지를 처리한다.
+    *  3. 서버는 그 결과를 /topic/meeting/{meetingId}/agendas/{agendaId}/status 주소로 브로커에게 보낸다.
+    *  4. 브로커는 해당 주소를 구독하고 있는 클라이언트에게 메세지를 전달한다.
+     */
     @Operation(summary = "안건 제어 및 갱신", description = "해당 안건을 제어 및 갱신한다.")
     @MessageMapping("/meeting/{meeting-id}/agendas/{agenda-id}/action")
     @SendTo("/topic/meeting/{meeting-id}/agendas/{agenda-id}/status")

--- a/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
+++ b/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
@@ -58,20 +58,20 @@ public class AgendaController {
         return ResponseEntity.ok(ApiUtils.success(agendaInfoResponseList));
     }
 
-    /*
-    * @MessageMapping : 클라이언트에서 해당 url로 메세지를 보내면 요청을 처리한다.
-    * @SendTo : 브로커에게 메세지를 보낸다.
-    *  과정
-    *  1. 클라이언트에서 /app/meeting/{meetingId}/agendas/{agendaId}/action 으로 메세지를 보낸다.
-    *  2. 핸들러가 메세지를 처리한다.
-    *  3. 그 결과를 /topic/meeting/{meetingId}/agendas/{agendaId}/status 주소로 브로커에게 보낸다.
-    *  4. 브로커는 해당 주소를 구독하고 있는 클라이언트에게 메세지를 전달한다.
-     */
+//    /*
+//    * @MessageMapping : 클라이언트에서 해당 url로 메세지를 보내면 요청을 처리한다.
+//    * @SendTo : 브로커에게 메세지를 보낸다.
+//    *  과정
+//    *  1. 클라이언트에서 /app/meeting/{meetingId}/agendas/{agendaId}/action 으로 메세지를 보낸다.
+//    *  2. 핸들러가 메세지를 처리한다.
+//    *  3. 서버는 그 결과를 /topic/meeting/{meetingId}/agendas/{agendaId}/status 주소로 브로커에게 보낸다.
+//    *  4. 브로커는 해당 주소를 구독하고 있는 클라이언트에게 메세지를 전달한다.
+//     */
     @Operation(summary = "안건 제어 및 갱신", description = "해당 안건을 제어 및 갱신한다.")
     @MessageMapping("/meeting/{meeting-id}/agendas/{agenda-id}/action")
     @SendTo("/topic/meeting/{meeting-id}/agendas/{agenda-id}/status")
-    public AgendaActionResponse handleAgendaAction(@DestinationVariable Long meetingId,
-                                                   @DestinationVariable Long agendaId,
+    public AgendaActionResponse handleAgendaAction(@DestinationVariable("meeting-id") Long meetingId,
+                                                   @DestinationVariable("agenda-id") Long agendaId,
                                                    AgendaActionRequest actionRequest) {
         // 로직 구현 (안건 상태 변경)
         Agenda agenda = agendaService.changeAgendaStatus(meetingId, agendaId, actionRequest);

--- a/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
@@ -10,7 +10,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalTime;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -39,17 +40,25 @@ public class Agenda extends AuditableEntity {
     @Enumerated(EnumType.STRING)
     private AgendaType type;
 
-    // 예상 소요 시간
-    @Column(nullable = false, name = "estimated_duration")
-    private LocalTime estimatedDuration;
+    // 할당된 총 시간
+    @Column(name = "allocated_duration", nullable = false)
+    private Duration allocatedDuration = Duration.ZERO;
 
-    // 연장된 총 시간
-    @Column(nullable = true, name = "extended_duration")
-    private LocalTime extendedDuration;
+    // 안건 시작 시간
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
 
-    // 실제 소요 시간
-    @Column(nullable = true, name = "actual_duration")
-    private LocalTime actualDuration;
+    // 안건 일시정지 시간
+    @Column(name = "pause_time")
+    private LocalDateTime pauseTime;
+
+    // 일시정지된 시간 누적
+    @Column(name = "paused_duration")
+    private Duration pausedDuration = Duration.ZERO;
+
+    // 안건 총 소요시간
+    @Column(name = "total_duration")
+    private Duration totalDuration;
 
     @Column(nullable = false, name = "order_num")
     private Integer orderNum;
@@ -57,67 +66,94 @@ public class Agenda extends AuditableEntity {
     @Enumerated(EnumType.STRING)
     private AgendaStatus status = AgendaStatus.PENDING;
 
-
     @Builder
-    public Agenda(Long id, Meeting meeting, String title, AgendaType type, LocalTime estimatedDuration,
-                  Integer orderNum, AgendaStatus status) {
-        this.id = id;
+    public Agenda(Meeting meeting, String title, AgendaType type, Duration allocatedDuration, Integer orderNum) {
         this.meeting = meeting;
         this.title = title;
         this.type = type;
-        this.estimatedDuration = estimatedDuration;
+        this.allocatedDuration = allocatedDuration;
         this.orderNum = orderNum;
-        this.status = status;
     }
 
+
     public void start() {
-        if (this.status != AgendaStatus.PENDING) {
-            throw new BadRequestError(BadRequestError.ErrorCode.WRONG_REQUEST_TRANSMISSION,
-                Collections.singletonMap("AgendaStatus", "Agenda can only be started from PENDING status"));
-        }
+        validateTransition(AgendaStatus.PENDING);
+        this.startTime = LocalDateTime.now();
         this.status = AgendaStatus.INPROGRESS;
     }
 
     public void pause() {
-        if (this.status != AgendaStatus.INPROGRESS) {
-            throw new BadRequestError(BadRequestError.ErrorCode.WRONG_REQUEST_TRANSMISSION,
-                Collections.singletonMap("AgendaStatus", "Agenda can only be paused from INPROGRESS status."));
-        }
+        validateTransition(AgendaStatus.INPROGRESS);
+        this.pauseTime = LocalDateTime.now(); // 일시정지 시간 설정
         this.status = AgendaStatus.PAUSED;
     }
 
     public void resume() {
-        if (this.status != AgendaStatus.PAUSED) {
-            throw new BadRequestError(BadRequestError.ErrorCode.WRONG_REQUEST_TRANSMISSION,
-                Collections.singletonMap("AgendaStatus", "Agenda can only be resumed from PAUSED status."));
-        }
+        validateTransition(AgendaStatus.PAUSED);
+        // 일시정지된 시간 누적
+        this.pausedDuration = this.pausedDuration.plus(Duration.between(pauseTime, LocalDateTime.now()));
+        this.pauseTime = null;
         this.status = AgendaStatus.INPROGRESS;
     }
 
-    public void extendDuration(LocalTime extension) {
-        if (this.extendedDuration == null) {
-            this.extendedDuration = extension;
-        } else {
-            this.extendedDuration = this.extendedDuration.plusHours(extension.getHour())
-                .plusMinutes(extension.getMinute());
+    public void extendDuration(Duration extension) {
+        if (this.status != AgendaStatus.COMPLETED) {
+            this.allocatedDuration = this.allocatedDuration.plus(extension);
         }
     }
 
     public void complete() {
-        if (this.status == AgendaStatus.COMPLETED) {
-            throw new BadRequestError(BadRequestError.ErrorCode.WRONG_REQUEST_TRANSMISSION,
-                Collections.singletonMap("AgendaStatus", "Agenda is already completed."));
-        }
+        validateTransition(AgendaStatus.INPROGRESS, AgendaStatus.PAUSED);
+
+        this.totalDuration = calculateCurrentDuration();
         this.status = AgendaStatus.COMPLETED;
-        this.actualDuration = calculateActualDuration(); // 실제 소요 시간 계산
     }
 
-    private LocalTime calculateActualDuration() {
-        if (this.extendedDuration != null) {
-            return this.estimatedDuration.plusHours(this.extendedDuration.getHour())
-                .plusMinutes(this.extendedDuration.getMinute());
+    // 현재까지 진행된 시간 계산
+    public Duration calculateCurrentDuration() {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (this.status == AgendaStatus.PENDING) {
+            return Duration.ZERO;
+        } else if (this.status == AgendaStatus.COMPLETED) {
+            return this.totalDuration;
+        } else { // INPROGRESS 또는 PAUSED 상태
+            Duration passedTime;
+            // PAUSED 상태라면, 마지막 일시정지 시간부터 현재까지의 시간을 뺀다
+            if (this.status == AgendaStatus.PAUSED && this.pauseTime != null) {
+                passedTime = Duration.between(this.startTime, this.pauseTime).minus(this.pausedDuration);
+            } else { // INPROGRESS 상태라면, 시작 시간부터 현재까지의 시간을 뺀다
+                passedTime = Duration.between(this.startTime, now).minus(this.pausedDuration);
+            }
+            return passedTime;
         }
-        return this.estimatedDuration;
+    }
+
+    // 남은 시간 계산 메서드 수정
+    public Duration calculateRemainingTime() {
+        ensureInProgressOrPaused();
+        // 현재까지 진행된 시간 계산
+        Duration passedTime = calculateCurrentDuration();
+        // 할당된 총 시간에서 현재까지 진행된 시간을 뺀다
+        return this.allocatedDuration.minus(passedTime);
+    }
+
+    private void ensureInProgressOrPaused() {
+        if (!(this.status == AgendaStatus.INPROGRESS || this.status == AgendaStatus.PAUSED)) {
+            throw new BadRequestError(BadRequestError.ErrorCode.WRONG_REQUEST_TRANSMISSION,
+                Collections.singletonMap("AgendaStatus",
+                    "Operation is only allowed for agendas in INPROGRESS or PAUSED status."));
+        }
+    }
+
+    private void validateTransition(AgendaStatus... validPreviousStatuses) {
+        for (AgendaStatus validStatus : validPreviousStatuses) {
+            if (this.status == validStatus) {
+                return;
+            }
+        }
+        throw new BadRequestError(BadRequestError.ErrorCode.WRONG_REQUEST_TRANSMISSION,
+            Collections.singletonMap("AgendaStatus", "Invalid status transition"));
     }
 
 }

--- a/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
@@ -87,7 +87,7 @@ public class Agenda extends AuditableEntity {
     }
 
     public void resume() {
-        if (this.status != AgendaStatus.PAUSED) {
+        if (this.status != AgendaStatus.PAUSED || this.status != AgendaStatus.COMPLETED){
             throw new BadRequestError(BadRequestError.ErrorCode.WRONG_REQUEST_TRANSMISSION,
                 Collections.singletonMap("AgendaStatus", "Agenda can only be resumed from PAUSED status."));
         }

--- a/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
@@ -113,7 +113,7 @@ public class Agenda extends AuditableEntity {
     public Duration calculateCurrentDuration() {
         LocalDateTime now = LocalDateTime.now();
 
-        if (this.status == AgendaStatus.PENDING) {
+        if (this.status == AgendaStatus.PENDING || this.status == AgendaStatus.CANCELED) {
             return Duration.ZERO;
         } else if (this.status == AgendaStatus.COMPLETED) {
             return this.totalDuration;
@@ -133,7 +133,7 @@ public class Agenda extends AuditableEntity {
     public Duration calculateRemainingTime() {
         if (this.status == AgendaStatus.PENDING) {
             return this.allocatedDuration;
-        } else if (this.status == AgendaStatus.COMPLETED) {
+        } else if (this.status == AgendaStatus.COMPLETED || this.status == AgendaStatus.CANCELED) {
             return Duration.ZERO;
         } else { // INPROGRESS 또는 PAUSED 상태
             // 현재까지 진행된 시간 계산

--- a/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
@@ -87,7 +87,7 @@ public class Agenda extends AuditableEntity {
     }
 
     public void resume() {
-        if (this.status != AgendaStatus.PAUSED || this.status != AgendaStatus.COMPLETED){
+        if (this.status != AgendaStatus.PAUSED) {
             throw new BadRequestError(BadRequestError.ErrorCode.WRONG_REQUEST_TRANSMISSION,
                 Collections.singletonMap("AgendaStatus", "Agenda can only be resumed from PAUSED status."));
         }

--- a/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
@@ -129,20 +129,17 @@ public class Agenda extends AuditableEntity {
         }
     }
 
-    // 남은 시간 계산 메서드 수정
+    // 남은 시간 계산 메서드
     public Duration calculateRemainingTime() {
-        ensureInProgressOrPaused();
-        // 현재까지 진행된 시간 계산
-        Duration passedTime = calculateCurrentDuration();
-        // 할당된 총 시간에서 현재까지 진행된 시간을 뺀다
-        return this.allocatedDuration.minus(passedTime);
-    }
-
-    private void ensureInProgressOrPaused() {
-        if (!(this.status == AgendaStatus.INPROGRESS || this.status == AgendaStatus.PAUSED)) {
-            throw new BadRequestError(BadRequestError.ErrorCode.WRONG_REQUEST_TRANSMISSION,
-                Collections.singletonMap("AgendaStatus",
-                    "Operation is only allowed for agendas in INPROGRESS or PAUSED status."));
+        if (this.status == AgendaStatus.PENDING) {
+            return this.allocatedDuration;
+        } else if (this.status == AgendaStatus.COMPLETED) {
+            return Duration.ZERO;
+        } else { // INPROGRESS 또는 PAUSED 상태
+            // 현재까지 진행된 시간 계산
+            Duration passedTime = calculateCurrentDuration();
+            // 할당된 총 시간에서 현재까지 진행된 시간을 뺀다
+            return this.allocatedDuration.minus(passedTime);
         }
     }
 

--- a/src/main/java/org/dnd/timeet/agenda/domain/AgendaAction.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/AgendaAction.java
@@ -1,0 +1,10 @@
+package org.dnd.timeet.agenda.domain;
+
+public enum AgendaAction {
+    START, PAUSE, RESUME, END, MODIFY;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+}

--- a/src/main/java/org/dnd/timeet/agenda/domain/AgendaStatus.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/AgendaStatus.java
@@ -1,5 +1,5 @@
 package org.dnd.timeet.agenda.domain;
 
 public enum AgendaStatus {
-    PENDING, INPROGRESS, PAUSED, COMPLETED
+    PENDING, INPROGRESS, PAUSED, COMPLETED, CANCELED
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaActionResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaActionResponse.java
@@ -1,21 +1,43 @@
 package org.dnd.timeet.agenda.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.dnd.timeet.agenda.domain.Agenda;
 import org.dnd.timeet.agenda.domain.AgendaStatus;
+import org.dnd.timeet.agenda.domain.AgendaType;
+import org.dnd.timeet.common.utils.DateTimeUtils;
+import org.dnd.timeet.common.utils.DurationUtils;
 
 @Schema(description = "안건 제어 응답")
 @Getter
 @Setter
 public class AgendaActionResponse {
+
     private Long agendaId;
     private AgendaStatus status;
+    private String title;
+    private AgendaType type;
 
-    public AgendaActionResponse(Long agendaId, AgendaStatus status) {
-        this.agendaId = agendaId;
-        this.status = status;
+    private String currentDuration; // 현재까지 진행된 시간
+    private String remainingDuration; // 남은 시간
+
+    private Integer orderNum;
+    private String timestamp; // 수정 시간
+
+    public AgendaActionResponse(Agenda agenda, Duration currentDuration, Duration remainingDuration) {
+        this.agendaId = agenda.getId();
+        this.status = agenda.getStatus();
+        this.title = agenda.getTitle();
+        this.type = agenda.getType();
+
+        this.currentDuration = DurationUtils.formatDuration(currentDuration);
+        this.remainingDuration = DurationUtils.formatDuration(remainingDuration);
+
+        this.orderNum = agenda.getOrderNum();
+        this.timestamp = DateTimeUtils.formatLocalDateTime(LocalDateTime.now());
     }
 
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaCreateRequest.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaCreateRequest.java
@@ -2,14 +2,13 @@ package org.dnd.timeet.agenda.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.dnd.timeet.agenda.domain.Agenda;
-import org.dnd.timeet.agenda.domain.AgendaStatus;
 import org.dnd.timeet.agenda.domain.AgendaType;
+import org.dnd.timeet.common.utils.DurationUtils;
 import org.dnd.timeet.meeting.domain.Meeting;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -31,7 +30,7 @@ public class AgendaCreateRequest {
     @NotNull(message = "안건 소요 시간은 반드시 입력되어야 합니다")
     @DateTimeFormat(pattern = "HH:mm")
     @Schema(description = "안건 소요 시간", example = "01:20")
-    private LocalTime estimatedDuration;
+    private LocalTime allocatedDuration;
 
     @NotNull(message = "안건 순서는 반드시 입력되어야 합니다")
     @Schema(description = "안건 순서", example = "1")
@@ -42,9 +41,8 @@ public class AgendaCreateRequest {
             .meeting(meeting)
             .title(this.title)
             .type(this.type.equals("AGENDA") ? AgendaType.AGENDA : AgendaType.BREAK)
-            .estimatedDuration(this.estimatedDuration)
+            .allocatedDuration(DurationUtils.convertLocalTimeToDuration(this.allocatedDuration))
             .orderNum(this.orderNum)
-            .status(AgendaStatus.PENDING)
             .build();
     }
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaInfoResponse.java
@@ -1,13 +1,13 @@
 package org.dnd.timeet.agenda.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalTime;
-import lombok.Builder;
+import java.time.Duration;
 import lombok.Getter;
 import lombok.Setter;
 import org.dnd.timeet.agenda.domain.Agenda;
+import org.dnd.timeet.common.utils.DurationUtils;
 
-@Schema(description = "회의 정보 응답")
+@Schema(description = "안건 정보 응답")
 @Getter
 @Setter
 public class AgendaInfoResponse {
@@ -15,45 +15,27 @@ public class AgendaInfoResponse {
     @Schema(description = "안건 id", example = "12")
     private Long agendaId;
 
-    @Schema(description = "안건 제목", example = "안건1")
+    @Schema(description = "안건 제목", example = "안건 1")
     private String title;
 
     @Schema(description = "안건 종류", example = "AGENDA")
     private String type;
 
-    @Schema(description = "예상 소요시간", example = "01:00")
-    private LocalTime estimatedDuration;
+    @Schema(description = "현재까지 소요된 시간", example = "00:36")
+    private String currentDuration;
 
-    @Schema(description = "연장된 총 시간", example = "00:30")
-    private LocalTime extendedDuration;
-
-    @Schema(description = "실제 소요시간", example = "01:30")
-    private LocalTime actualDuration;
+    @Schema(description = "남은 시간", example = "00:24")
+    private String remainingDuration;
 
     @Schema(description = "안건 상태", example = "INPROGRESS")
     private String status;
 
-    @Builder
-    public AgendaInfoResponse(Long agendaId, String title, String type, LocalTime estimatedDuration, LocalTime extendedDuration, LocalTime actualDuration, String status) {
-        this.agendaId = agendaId;
-        this.title = title;
-        this.type = type;
-        this.estimatedDuration = estimatedDuration;
-        this.extendedDuration = extendedDuration;
-        this.actualDuration = actualDuration;
-        this.status = status;
-    }
-
-
-    public static AgendaInfoResponse from(Agenda agenda) { // 매개변수로부터 객체를 생성하는 팩토리 메서드
-        return AgendaInfoResponse.builder()
-            .agendaId(agenda.getId())
-            .title(agenda.getTitle())
-            .type(agenda.getType().name())
-            .estimatedDuration(agenda.getEstimatedDuration())
-            .extendedDuration(agenda.getExtendedDuration())
-            .actualDuration(agenda.getActualDuration())
-            .status(agenda.getStatus().name())
-            .build();
+    public AgendaInfoResponse(Agenda agenda, Duration currentDuration, Duration remainingDuration) {
+        this.agendaId = agenda.getId();
+        this.title = agenda.getTitle();
+        this.type = agenda.getType().name();
+        this.currentDuration = DurationUtils.formatDuration(currentDuration);
+        this.remainingDuration = DurationUtils.formatDuration(remainingDuration);
+        this.status = agenda.getStatus().name();
     }
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaInfoResponse.java
@@ -24,6 +24,9 @@ public class AgendaInfoResponse {
     @Schema(description = "예상 소요시간", example = "01:00")
     private LocalTime estimatedDuration;
 
+    @Schema(description = "연장된 총 시간", example = "00:30")
+    private LocalTime extendedDuration;
+
     @Schema(description = "실제 소요시간", example = "01:30")
     private LocalTime actualDuration;
 
@@ -31,11 +34,12 @@ public class AgendaInfoResponse {
     private String status;
 
     @Builder
-    public AgendaInfoResponse(Long agendaId, String title, String type, LocalTime estimatedDuration, LocalTime actualDuration, String status) {
+    public AgendaInfoResponse(Long agendaId, String title, String type, LocalTime estimatedDuration, LocalTime extendedDuration, LocalTime actualDuration, String status) {
         this.agendaId = agendaId;
         this.title = title;
         this.type = type;
         this.estimatedDuration = estimatedDuration;
+        this.extendedDuration = extendedDuration;
         this.actualDuration = actualDuration;
         this.status = status;
     }
@@ -47,6 +51,7 @@ public class AgendaInfoResponse {
             .title(agenda.getTitle())
             .type(agenda.getType().name())
             .estimatedDuration(agenda.getEstimatedDuration())
+            .extendedDuration(agenda.getExtendedDuration())
             .actualDuration(agenda.getActualDuration())
             .status(agenda.getStatus().name())
             .build();

--- a/src/main/java/org/dnd/timeet/common/utils/DateTimeUtils.java
+++ b/src/main/java/org/dnd/timeet/common/utils/DateTimeUtils.java
@@ -1,0 +1,23 @@
+package org.dnd.timeet.common.utils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeUtils {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+    /**
+     * LocalDateTime 객체를 yyyy-MM-dd'T'HH:mm:ss 형식의 문자열로 포매팅한다.
+     *
+     * @param localDateTime LocalDateTime 객체
+     * @return 포매팅된 문자열
+     */
+    public static String formatLocalDateTime(LocalDateTime localDateTime) {
+        if (localDateTime == null) {
+            return null;
+        }
+        return localDateTime.format(FORMATTER);
+    }
+}
+

--- a/src/main/java/org/dnd/timeet/common/utils/DurationUtils.java
+++ b/src/main/java/org/dnd/timeet/common/utils/DurationUtils.java
@@ -1,0 +1,41 @@
+package org.dnd.timeet.common.utils;
+
+import java.time.Duration;
+import java.time.LocalTime;
+
+public class DurationUtils {
+
+    /**
+     * LocalTime 객체를 Duration으로 변환한다.
+     * @param time LocalTime 객체
+     * @return Duration 객체
+     */
+    public static Duration convertLocalTimeToDuration(LocalTime time) {
+        int totalMinutes = time.getHour() * 60 + time.getMinute();
+        return Duration.ofMinutes(totalMinutes);
+    }
+
+    /**
+     * Duration 객체를 HH:mm 형식의 문자열로 포매팅한다.
+     * @param duration Duration 객체
+     * @return 포매팅된 시간 문자열 (HH:mm)
+     */
+    public static String formatDuration(Duration duration) {
+        long hours = duration.toHours();
+        long minutes = duration.toMinutes() % 60;
+        return String.format("%02d:%02d", hours, minutes);
+    }
+
+    public static void main(String[] args) {
+        // 변환 테스트
+        String timeString = "02:30";
+        LocalTime time = LocalTime.parse(timeString);
+        Duration duration = convertLocalTimeToDuration(time);
+        System.out.println("Converted Duration: " + duration); // PT2H30M
+
+        // 포매팅 테스트
+        String formattedDuration = formatDuration(duration);
+        System.out.println("Formatted Duration: " + formattedDuration); // 02:30
+    }
+}
+

--- a/src/main/java/org/dnd/timeet/common/utils/DurationUtils.java
+++ b/src/main/java/org/dnd/timeet/common/utils/DurationUtils.java
@@ -7,6 +7,7 @@ public class DurationUtils {
 
     /**
      * LocalTime 객체를 Duration으로 변환한다.
+     *
      * @param time LocalTime 객체
      * @return Duration 객체
      */
@@ -17,6 +18,7 @@ public class DurationUtils {
 
     /**
      * Duration 객체를 HH:mm 형식의 문자열로 포매팅한다.
+     *
      * @param duration Duration 객체
      * @return 포매팅된 시간 문자열 (HH:mm)
      */
@@ -24,18 +26,6 @@ public class DurationUtils {
         long hours = duration.toHours();
         long minutes = duration.toMinutes() % 60;
         return String.format("%02d:%02d", hours, minutes);
-    }
-
-    public static void main(String[] args) {
-        // 변환 테스트
-        String timeString = "02:30";
-        LocalTime time = LocalTime.parse(timeString);
-        Duration duration = convertLocalTimeToDuration(time);
-        System.out.println("Converted Duration: " + duration); // PT2H30M
-
-        // 포매팅 테스트
-        String formattedDuration = formatDuration(duration);
-        System.out.println("Formatted Duration: " + formattedDuration); // 02:30
     }
 }
 

--- a/src/main/java/org/dnd/timeet/config/WebSocketConfig.java
+++ b/src/main/java/org/dnd/timeet/config/WebSocketConfig.java
@@ -20,7 +20,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     // 웹소켓 연결을 위한 endpoint 설정
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").withSockJS(); // /ws로 접속하면 SockJS를 통해 웹소켓 연결
+        registry.addEndpoint("/ws")
+            .setAllowedOriginPatterns("*"); // 모든 도메인에서 접근 허용
+//            .withSockJS(); // /ws로 접속하면 SockJS를 통해 웹소켓 연결
     }
 }
 

--- a/src/test/java/org/dnd/timeet/TimeetApplicationTests.java
+++ b/src/test/java/org/dnd/timeet/TimeetApplicationTests.java
@@ -5,7 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
-@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"})
 class TimeetApplicationTests {
 
     @Test

--- a/src/test/java/org/dnd/timeet/common/utils/DurationUtilsTest.java
+++ b/src/test/java/org/dnd/timeet/common/utils/DurationUtilsTest.java
@@ -1,0 +1,21 @@
+package org.dnd.timeet.common.utils;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import org.junit.jupiter.api.Test;
+
+public class DurationUtilsTest {
+
+    @Test
+    public void test() {
+        // 변환 테스트
+        String timeString = "02:30";
+        LocalTime time = LocalTime.parse(timeString);
+        Duration duration = DurationUtils.convertLocalTimeToDuration(time);
+        System.out.println("Converted Duration: " + duration); // PT2H30M
+
+        // 포매팅 테스트
+        String formattedDuration = DurationUtils.formatDuration(duration);
+        System.out.println("Formatted Duration: " + formattedDuration); // 02:30
+    }
+}


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #24 

resolved: #24 

### 🛠 개발 기능
- `실시간 소켓 API` 연결 에러 수정
- `안건 제어 API `로직 에러 수정 및 타이머 로직 개선
- 남은 시간 계산 로직 개선 
- `DateTimeUtils` 및 `DurationUtils` 추가
- `Agenda`의 컨트롤러 및 서비스 로직 업데이트
- 추가된 `CANCELED` 상태 반영 및 관련 로직 업데이트

### 🧩 해결 방법
- **안건(타이머) 로직 개선**: 타이머 기능을 일시 정지, 연장 기능을 지원하도록 확장했습니다.
- **안건 조회 API 수정** : 각 안건의 소요시간과 남은 시간을 안건 상태에 따라 실시간으로 확인할 수 있도록 했습니다.
- **DateTimeUtils 및 DurationUtils 추가**: LocalDateTime 포매팅과 Duration 관련 메서드를 묶어 각각 유틸리티 클래스에 추가했습니다.
- **안건 컨트롤러 및 서비스 로직 업데이트**: 새로운 타이머 로직과 CANCELED 상태를 반영하여 리팩토링했습니다.

### 🔍 리뷰 포인트
- **변경된 타이머 로직**: 안건 상태에 따라 타이머 로직이 잘 짜여졌는지 확인해 주세요 !


<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
