### PR TITLE
[Feat/#35] 스케줄링을 통한 자동 회의 시작 기능 구현 및 남은 시간 조회 기능 구현

### DIFF
--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaReportInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaReportInfoResponse.java
@@ -37,7 +37,7 @@ public class AgendaReportInfoResponse {
         return AgendaReportInfoResponse.builder()
             .agendaId(agenda.getId())
             .title(agenda.getTitle())
-            .diff(formatDuration(calculateTimeDiff(agenda.getActualDuration(), agenda.getEstimatedDuration())))
+            .diff(formatDuration(calculateTimeDiff(agenda.getTotalDuration(), agenda.getAllocatedDuration())))
             .build();
     }
 }

--- a/src/main/java/org/dnd/timeet/common/utils/DurationUtils.java
+++ b/src/main/java/org/dnd/timeet/common/utils/DurationUtils.java
@@ -17,15 +17,16 @@ public class DurationUtils {
     }
 
     /**
-     * Duration 객체를 HH:mm 형식의 문자열로 포매팅한다.
+     * Duration 객체를 HH:mm:ss 형식의 문자열로 포매팅한다.
      *
      * @param duration Duration 객체
-     * @return 포매팅된 시간 문자열 (HH:mm)
+     * @return 포매팅된 시간 문자열 (HH:mm:ss)
      */
     public static String formatDuration(Duration duration) {
         long hours = duration.toHours();
-        long minutes = duration.toMinutes() % 60;
-        return String.format("%02d:%02d", hours, minutes);
+        long minutes = duration.toMinutesPart();
+        long seconds = duration.toSecondsPart();
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
     }
 }
 

--- a/src/main/java/org/dnd/timeet/common/utils/TimeUtils.java
+++ b/src/main/java/org/dnd/timeet/common/utils/TimeUtils.java
@@ -1,24 +1,23 @@
 package org.dnd.timeet.common.utils;
 
 import java.time.Duration;
-import java.time.LocalTime;
 import java.util.Collections;
 import org.dnd.timeet.common.exception.InternalServerError;
 
 public class TimeUtils {
 
-    public static Duration calculateTimeDiff(LocalTime ActualDuration, LocalTime EstimatedDuration) {
+    public static Duration calculateTimeDiff(Duration actualDuration, Duration estimatedDuration) {
 
-        if (ActualDuration == null) {
+        if (actualDuration == null) {
             throw new InternalServerError(InternalServerError.ErrorCode.INTERNAL_SERVER_ERROR,
                 Collections.singletonMap("LocalTime", "ActualDuration is null"));
         }
-        if (EstimatedDuration == null) {
+        if (estimatedDuration == null) {
             throw new InternalServerError(InternalServerError.ErrorCode.INTERNAL_SERVER_ERROR,
-                Collections.singletonMap("LocalTime", "EstimatedDuration is null"));
+                Collections.singletonMap("LocalTime", "estimatedDuration is null"));
         }
-
-        return Duration.between(EstimatedDuration, ActualDuration);
+        // actualDuration - estimatedDuration
+        return actualDuration.minus(estimatedDuration);
     }
 
     public static String formatDuration(Duration duration) {

--- a/src/main/java/org/dnd/timeet/config/AsyncConfig.java
+++ b/src/main/java/org/dnd/timeet/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package org.dnd.timeet.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/org/dnd/timeet/config/SchedulerConfig.java
+++ b/src/main/java/org/dnd/timeet/config/SchedulerConfig.java
@@ -1,0 +1,19 @@
+package org.dnd.timeet.config;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SchedulerConfig {
+
+    private final int poolSize = 10;
+
+    // 스프링 컨테이너가 종료될 때 스케줄러 작업 종료 및 스레드 풀 정리
+    @Bean(destroyMethod = "shutdown")
+    public ScheduledExecutorService taskScheduler() {
+        return Executors.newScheduledThreadPool(poolSize);
+    }
+}
+

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingAsyncService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingAsyncService.java
@@ -1,0 +1,37 @@
+package org.dnd.timeet.meeting.application;
+
+import java.util.Collections;
+import org.dnd.timeet.common.exception.NotFoundError;
+import org.dnd.timeet.meeting.domain.Meeting;
+import org.dnd.timeet.meeting.domain.MeetingRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MeetingAsyncService {
+
+    private final MeetingRepository meetingRepository;
+    private final Logger logger = LoggerFactory.getLogger(MeetingAsyncService.class);
+
+    public MeetingAsyncService(MeetingRepository meetingRepository) {
+        this.meetingRepository = meetingRepository;
+    }
+
+    @Transactional
+    @Async // 비동기 작업 실행시 발생하는 에러 처리
+    public void startScheduledMeeting(Long meetingId) {
+        try {
+            Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new NotFoundError(NotFoundError.ErrorCode.RESOURCE_NOT_FOUND,
+                    Collections.singletonMap("MeetingId", "Meeting not found")));
+
+            meeting.startMeeting();
+            meetingRepository.save(meeting);
+        } catch (Exception e) {
+            logger.error("Error starting scheduled meeting", e);
+        }
+    }
+}

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingScheduler.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingScheduler.java
@@ -1,0 +1,32 @@
+package org.dnd.timeet.meeting.application;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.dnd.timeet.common.exception.BadRequestError;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.stereotype.Service;
+
+@EnableScheduling
+@Service
+@RequiredArgsConstructor
+public class MeetingScheduler {
+
+    private final MeetingAsyncService meetingAsyncService;
+    private final ScheduledExecutorService scheduledExecutorService;
+
+    public void scheduleMeetingStart(Long meetingId, LocalDateTime startTime) {
+        long delay = ChronoUnit.MILLIS.between(LocalDateTime.now(), startTime);
+        if (delay < 0) {
+            throw new BadRequestError(BadRequestError.ErrorCode.VALIDATION_FAILED,
+                Collections.singletonMap("startTime", "startTime is past"));
+        }
+
+        // 스케줄러 생성
+        scheduledExecutorService.schedule(() ->
+            meetingAsyncService.startScheduledMeeting(meetingId), delay, TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
@@ -31,6 +31,8 @@ public class MeetingService {
     private final MeetingRepository meetingRepository;
     private final ParticipantRepository participantRepository;
     private final AgendaRepository agendaRepository;
+    private final MeetingScheduler meetingScheduler;
+
 
     public Meeting createMeeting(MeetingCreateRequest createDto, Member member) {
         Meeting meeting = createDto.toEntity(member);
@@ -38,6 +40,9 @@ public class MeetingService {
 
         Participant participant = new Participant(meeting, member);
         participantRepository.save(participant);
+
+        // 스케줄러를 통해 회의 시작 시간에 회의 시작
+        meetingScheduler.scheduleMeetingStart(meeting.getId(), meeting.getStartTime());
 
         return meeting;
     }

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
@@ -13,9 +13,11 @@ import org.dnd.timeet.agenda.domain.AgendaType;
 import org.dnd.timeet.agenda.dto.AgendaReportInfoResponse;
 import org.dnd.timeet.common.exception.BadRequestError;
 import org.dnd.timeet.common.exception.NotFoundError;
+import org.dnd.timeet.common.exception.NotFoundError.ErrorCode;
 import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.domain.MeetingRepository;
 import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
+import org.dnd.timeet.meeting.dto.MeetingRemainingTimeResponse;
 import org.dnd.timeet.meeting.dto.MeetingReportInfoResponse;
 import org.dnd.timeet.member.domain.Member;
 import org.dnd.timeet.participant.domain.Participant;
@@ -136,6 +138,15 @@ public class MeetingService {
         return meeting.getParticipants().stream()
             .map(Participant::getMember)
             .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public MeetingRemainingTimeResponse getRemainingTime(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+            .orElseThrow(() -> new NotFoundError(ErrorCode.RESOURCE_NOT_FOUND,
+                Collections.singletonMap("MeetingId", "Meeting not found")));
+
+        return MeetingRemainingTimeResponse.from(meeting);
     }
 
 }

--- a/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
@@ -14,11 +14,15 @@ import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
 import org.dnd.timeet.meeting.dto.MeetingCreateResponse;
 import org.dnd.timeet.meeting.dto.MeetingInfoResponse;
+import org.dnd.timeet.meeting.dto.MeetingRemainingTimeResponse;
 import org.dnd.timeet.meeting.dto.MeetingReportInfoResponse;
 import org.dnd.timeet.meeting.dto.MeetingReportResponse;
 import org.dnd.timeet.member.dto.MemberInfoListResponse;
 import org.dnd.timeet.member.dto.MemberInfoResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -78,6 +82,16 @@ public class MeetingController {
         MeetingInfoResponse meetingInfoResponse = MeetingInfoResponse.from(meeting);
 
         return ResponseEntity.ok(ApiUtils.success(meetingInfoResponse));
+    }
+
+    @Operation(summary = "남은 시간 조회", description = "웹소켓을 통해 특정 회의의 남은 시간을 조회한다.")
+    @MessageMapping("/meeting/{meeting-id}/remaining-time")
+    @SendTo("/topic/meeting/{meeting-id}/remaining-time")
+    public ResponseEntity<ApiResult<MeetingRemainingTimeResponse>> getRemainingTime(
+        @DestinationVariable("meeting-id") Long meetingId) {
+        MeetingRemainingTimeResponse response = meetingService.getRemainingTime(meetingId);
+
+        return ResponseEntity.ok(ApiUtils.success(response));
     }
 
     @GetMapping("{meeting-id}/report")

--- a/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
+++ b/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
@@ -150,6 +150,41 @@ public class Meeting extends AuditableEntity {
         this.assignHostMember(newHost);
     }
 
+    // 현재까지 진행된 시간 계산
+    public Duration calculateCurrentDuration() {
+        switch (this.status) {
+            case SCHEDULED:
+                return Duration.ZERO;
+            case INPROGRESS:
+                return Duration.between(this.startTime, LocalDateTime.now());
+            case COMPLETED:
+                return this.totalActualDuration;
+            case CANCELED:
+                throw new BadRequestError(ErrorCode.WRONG_REQUEST_TRANSMISSION,
+                    Collections.singletonMap("Meeting", "Meeting is CANCELED"));
+            default:
+                throw new BadRequestError(ErrorCode.WRONG_REQUEST_TRANSMISSION,
+                    Collections.singletonMap("Meeting", "MeetingStatus is not valid"));
+        }
+    }
+
+    // 남은 시간 계산 메서드
+    public Duration calculateRemainingTime() {
+        switch (this.status) {
+            case SCHEDULED:
+                return this.totalEstimatedDuration;
+            case INPROGRESS:
+                return this.totalEstimatedDuration.minus(calculateCurrentDuration());
+            case COMPLETED:
+                return Duration.ZERO;
+            case CANCELED:
+                throw new BadRequestError(ErrorCode.WRONG_REQUEST_TRANSMISSION,
+                    Collections.singletonMap("Meeting", "Meeting is CANCELED"));
+            default:
+                throw new BadRequestError(ErrorCode.WRONG_REQUEST_TRANSMISSION,
+                    Collections.singletonMap("Meeting", "MeetingStatus is not valid"));
+        }
+    }
 
 }
 

--- a/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
+++ b/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
@@ -13,7 +13,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -55,11 +54,11 @@ public class Meeting extends AuditableEntity {
 
     // 예상 소요 시간
     @Column(nullable = false, name = "total_estimated_duration")
-    private LocalTime totalEstimatedDuration;
+    private Duration totalEstimatedDuration;
 
     // 실제 소요 시간, 초기값 null
     @Column(name = "total_actual_duration")
-    private LocalTime totalActualDuration;
+    private Duration totalActualDuration;
 
     @Column(nullable = true, length = 255)
     private String location;
@@ -78,7 +77,7 @@ public class Meeting extends AuditableEntity {
     private Set<Participant> participants = new HashSet<>();
 
     @Builder
-    public Meeting(Member hostMember, String title, LocalDateTime startTime, LocalTime totalEstimatedDuration,
+    public Meeting(Member hostMember, String title, LocalDateTime startTime, Duration totalEstimatedDuration,
                    String location, String description, Integer imgNum) {
         this.hostMember = hostMember;
         this.title = title;
@@ -104,14 +103,14 @@ public class Meeting extends AuditableEntity {
 
         this.status = MeetingStatus.COMPLETED;
 
-        long durationInSeconds = Duration.between(startTime, endTime).getSeconds();
+        Duration duration = Duration.between(startTime, endTime);
 
-        if (durationInSeconds > 24 * 3600) { // 하루를 초과하는 경우
+        if (duration.getSeconds() > 24 * 3600) { // 하루를 초과하는 경우
             throw new BadRequestError(ErrorCode.WRONG_REQUEST_TRANSMISSION,
                 Collections.singletonMap("Meeting", "Meeting duration exceeds one day"));
         }
 
-        this.totalActualDuration = LocalTime.ofSecondOfDay(durationInSeconds);
+        this.totalActualDuration = duration;
     }
 
     public void cancelMeeting() {

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingCreateRequest.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingCreateRequest.java
@@ -2,12 +2,12 @@ package org.dnd.timeet.meeting.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.dnd.timeet.common.utils.DurationUtils;
 import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.member.domain.Member;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -50,7 +50,7 @@ public class MeetingCreateRequest {
             .location(this.location)
             .startTime(startTime)
             .description(this.description)
-            .totalEstimatedDuration(this.estimatedTotalDuration)
+            .totalEstimatedDuration(DurationUtils.convertLocalTimeToDuration(this.estimatedTotalDuration))
             .imgNum(imageNum)
             .build();
     }

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
@@ -1,9 +1,11 @@
 package org.dnd.timeet.meeting.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.dnd.timeet.common.utils.DurationUtils;
 import org.dnd.timeet.meeting.domain.Meeting;
 
 @Schema(description = "회의 정보 응답")
@@ -17,22 +19,48 @@ public class MeetingInfoResponse {
     @Schema(description = "회의 제목", example = "2차 회의")
     private String title;
 
-    @Schema(description = "회의 목표", example = "2개의 사안 모두 해결하기")
+    @Schema(description = "회의 공지사항", example = "2개의 사안 모두 해결하기")
     private String description;
 
+    @Schema(description = "회의 상태", example = "SCHEDULED")
+    private String meetingStatus;
+
+    @Schema(description = "회의 방장 멤버 ID", example = "13")
+    private Long hostMemberId;
+
+    @Schema(description = "회의 시작 일자", example = "2024-01-11T13:20")
+    private String startTime;
+
+    @Schema(description = "예상 소요시간", example = "03:00:00")
+    private String totalEstimatedDuration;
+
+    @Schema(description = "썸네일 이미지 번호", example = "1")
+    private Integer imgNum;
+
     @Builder
-    public MeetingInfoResponse(Long meetingId, String title, String description) {
+    public MeetingInfoResponse(Long meetingId, String title, String description, String meetingStatus,
+                               Long hostMemberId,
+                               String startTime, Duration totalEstimatedDuration, Integer imgNum) {
         this.meetingId = meetingId;
         this.title = title;
         this.description = description;
+        this.meetingStatus = meetingStatus;
+        this.hostMemberId = hostMemberId;
+        this.startTime = startTime;
+        this.totalEstimatedDuration = DurationUtils.formatDuration(totalEstimatedDuration);
+        this.imgNum = imgNum;
     }
-
 
     public static MeetingInfoResponse from(Meeting meeting) { // 매개변수로부터 객체를 생성하는 팩토리 메서드
         return MeetingInfoResponse.builder()
             .meetingId(meeting.getId())
             .title(meeting.getTitle())
             .description(meeting.getDescription())
+            .meetingStatus(meeting.getStatus().name())
+            .hostMemberId(meeting.getHostMember().getId())
+            .startTime(meeting.getStartTime().toString())
+            .totalEstimatedDuration(meeting.getTotalEstimatedDuration())
+            .imgNum(meeting.getImgNum())
             .build();
     }
 }

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
@@ -34,13 +34,17 @@ public class MeetingInfoResponse {
     @Schema(description = "예상 소요시간", example = "03:00:00")
     private String totalEstimatedDuration;
 
+    @Schema(description = "회의 남은 시간", example = "00:03:00")
+    private String remainingTime;
+
     @Schema(description = "썸네일 이미지 번호", example = "1")
     private Integer imgNum;
 
     @Builder
     public MeetingInfoResponse(Long meetingId, String title, String description, String meetingStatus,
                                Long hostMemberId,
-                               String startTime, Duration totalEstimatedDuration, Integer imgNum) {
+                               String startTime, Duration totalEstimatedDuration, String remainingTime,
+                               Integer imgNum) {
         this.meetingId = meetingId;
         this.title = title;
         this.description = description;
@@ -48,6 +52,7 @@ public class MeetingInfoResponse {
         this.hostMemberId = hostMemberId;
         this.startTime = startTime;
         this.totalEstimatedDuration = DurationUtils.formatDuration(totalEstimatedDuration);
+        this.remainingTime = remainingTime;
         this.imgNum = imgNum;
     }
 
@@ -60,6 +65,7 @@ public class MeetingInfoResponse {
             .hostMemberId(meeting.getHostMember().getId())
             .startTime(meeting.getStartTime().toString())
             .totalEstimatedDuration(meeting.getTotalEstimatedDuration())
+            .remainingTime(DurationUtils.formatDuration(meeting.calculateRemainingTime()))
             .imgNum(meeting.getImgNum())
             .build();
     }

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingRemainingTimeResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingRemainingTimeResponse.java
@@ -1,0 +1,39 @@
+package org.dnd.timeet.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.dnd.timeet.common.utils.DurationUtils;
+import org.dnd.timeet.meeting.domain.Meeting;
+
+@Schema(description = "회의 정보 응답")
+@Getter
+@Setter
+public class MeetingRemainingTimeResponse {
+
+    @Schema(description = "회의 id", example = "12L")
+    private Long meetingId;
+
+    @Schema(description = "회의 상태", example = "SCHEDULED")
+    private String meetingStatus;
+
+    @Schema(description = "회의 남은 시간", example = "00:03:00")
+    private String remainingTime;
+
+    @Builder
+    public MeetingRemainingTimeResponse(Long meetingId, String meetingStatus, String remainingTime) {
+        this.meetingId = meetingId;
+        this.meetingStatus = meetingStatus;
+        this.remainingTime = remainingTime;
+    }
+
+    public static MeetingRemainingTimeResponse from(Meeting meeting) { // 매개변수로부터 객체를 생성하는 팩토리 메서드
+        return MeetingRemainingTimeResponse
+            .builder()
+            .meetingId(meeting.getId())
+            .meetingStatus(meeting.getStatus().name())
+            .remainingTime(DurationUtils.formatDuration(meeting.calculateRemainingTime()))
+            .build();
+    }
+}


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #35 
- [x] #39 

- resolved: #35 
- resolved: #39 

### 🛠 개발 기능
- 스케줄링을 통한 자동 회의 시작 기능
- 회의 남은 시간 조회 기능

### 🧩 해결 방법
- 자동 회의 시작 기능: 스케줄링을 통해 회의가 자동으로 시작되는 기능을 구현했습니다.
- 회의 남은 시간 조회 기능: WebSocket을 사용하여 회의의 남은 시간을 실시간으로 조회할 수 있도록 했습니다.

### 🔍 리뷰 포인트
- 시간 로직이 적절하게 잘 짜여졌는지 확인해주세요 :)


<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
