### PR TITLE
[Feat/#37] 웹소켓 연결에 JWT 기반 인증을 적용한다.

### DIFF
--- a/src/main/java/org/dnd/timeet/common/interceptor/JwtChannelInterceptor.java
+++ b/src/main/java/org/dnd/timeet/common/interceptor/JwtChannelInterceptor.java
@@ -1,0 +1,72 @@
+package org.dnd.timeet.common.interceptor;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.dnd.timeet.common.security.CustomUserDetails;
+import org.dnd.timeet.common.security.JwtProvider;
+import org.dnd.timeet.member.application.MemberFindService;
+import org.dnd.timeet.member.domain.Member;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * WebSocket 채널에 JWT 검증하는 인터셉터
+ */
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+    private final MemberFindService userUtilityService;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        // 연결 요청시 JWT 검증
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            // Authorization 헤더 추출
+            List<String> authorization = accessor.getNativeHeader(JwtProvider.HEADER);
+            if (authorization != null && !authorization.isEmpty()) {
+                String jwt = authorization.get(0).substring(JwtProvider.TOKEN_PREFIX.length());
+                try {
+                    // JWT 토큰 검증
+                    DecodedJWT decodedJWT = JwtProvider.verify(jwt);
+                    Long id = decodedJWT.getClaim("id").asLong();
+                    // 사용자 정보 조회
+                    Member member = userUtilityService.getUserById(id);
+
+                    // 사용자 인증 정보 설정
+                    CustomUserDetails userDetails = new CustomUserDetails(member);
+                    UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } catch (JWTVerificationException e) {
+                    log.error("JWT Verification Failed: " + e.getMessage());
+                    return null;
+                } catch (Exception e) {
+                    log.error("An unexpected error occurred: " + e.getMessage());
+                    return null;
+                }
+            } else {
+                // 클라이언트 측 타임아웃 처리
+                log.error("Authorization header is not found");
+                return null;
+            }
+        }
+        return message;
+    }
+}
+
+

--- a/src/main/java/org/dnd/timeet/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/dnd/timeet/common/security/JwtAuthenticationFilter.java
@@ -40,11 +40,11 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
         throws IOException, ServletException {
 
-        String jwt = request.getHeader(JWTProvider.HEADER);
+        String jwt = request.getHeader(JwtProvider.HEADER);
 
         try {
             if (jwt != null && !isNonProtectedUrl(request)) { // 토큰이 있고 보호된 URL일 경우 토큰 검증
-                DecodedJWT decodedJWT = JWTProvider.verify(jwt);
+                DecodedJWT decodedJWT = JwtProvider.verify(jwt);
                 Long id = decodedJWT.getClaim("id").asLong();
 
                 Member member = userUtilityService.getUserById(id);

--- a/src/main/java/org/dnd/timeet/common/security/JwtProvider.java
+++ b/src/main/java/org/dnd/timeet/common/security/JwtProvider.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class JWTProvider {
+public class JwtProvider {
 
     public static final Long EXP = 1000L * 60 * 60 * 48; // 48시간
     public static final String TOKEN_PREFIX = "Bearer ";

--- a/src/main/java/org/dnd/timeet/config/SecurityConfig.java
+++ b/src/main/java/org/dnd/timeet/config/SecurityConfig.java
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -129,9 +128,9 @@ public class SecurityConfig {
 
         // 인증, 권한 필터 설정
         http.authorizeHttpRequests(auth -> auth
-                .requestMatchers(PUBLIC_URLS).permitAll() // 인증 없이 접근 허용
+            .requestMatchers(PUBLIC_URLS).permitAll() // 인증 없이 접근 허용
 
-                .anyRequest().authenticated()
+            .anyRequest().authenticated()
         );
 
         http.oauth2Login(oauth2 -> oauth2

--- a/src/main/java/org/dnd/timeet/config/WebSocketConfig.java
+++ b/src/main/java/org/dnd/timeet/config/WebSocketConfig.java
@@ -1,6 +1,9 @@
 package org.dnd.timeet.config;
 
+import org.dnd.timeet.common.interceptor.JwtChannelInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -9,6 +12,9 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Autowired
+    private JwtChannelInterceptor jwtChannelInterceptor;
 
     // 메시지 브로커 설정
     @Override
@@ -23,6 +29,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
             .setAllowedOriginPatterns("*"); // 모든 도메인에서 접근 허용
 //            .withSockJS(); // /ws로 접속하면 SockJS를 통해 웹소켓 연결
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtChannelInterceptor);
     }
 }
 

--- a/src/main/java/org/dnd/timeet/meeting/application/WebSocketSessionManager.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/WebSocketSessionManager.java
@@ -1,0 +1,31 @@
+package org.dnd.timeet.meeting.application;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Service;
+
+/**
+ * 활성 사용자 수 추적 및 세션 관리
+ */
+@Service
+public class WebSocketSessionManager {
+
+    private final AtomicInteger activeUserCount = new AtomicInteger(0);
+    private final Map<String, Long> sessionUserMap = new ConcurrentHashMap<>();
+
+    public void addUserSession(String sessionId, Long userId) {
+        sessionUserMap.put(sessionId, userId);
+        activeUserCount.incrementAndGet();
+    }
+
+    public void removeUserSession(String sessionId) {
+        if (sessionUserMap.remove(sessionId) != null) {
+            activeUserCount.decrementAndGet();
+        }
+    }
+
+    public int getActiveUserCount() {
+        return activeUserCount.get();
+    }
+}

--- a/src/main/java/org/dnd/timeet/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/org/dnd/timeet/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -15,7 +15,7 @@ import org.dnd.timeet.common.exception.BadRequestError;
 import org.dnd.timeet.common.exception.BadRequestError.ErrorCode;
 import org.dnd.timeet.common.security.CookieAuthorizationRequestRepository;
 import org.dnd.timeet.common.security.CustomUserDetails;
-import org.dnd.timeet.common.security.JWTProvider;
+import org.dnd.timeet.common.security.JwtProvider;
 import org.dnd.timeet.common.utils.CookieUtil;
 import org.dnd.timeet.member.domain.Member;
 import org.dnd.timeet.member.domain.MemberRepository;
@@ -65,7 +65,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         // jwt
 
-        String accessToken = JWTProvider.create(user.get());
+        String accessToken = JwtProvider.create(user.get());
 
         return UriComponentsBuilder.fromUriString(targetUrl)
             .queryParam("code", accessToken)


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #37 

resolved: #37 

### 🛠 개발 기능
- Java 네이밍 컨벤션에 따라 `JWTProvider` 클래스명을 `JwtProvider`로 수정
- 웹소켓 연결시 JWT 토큰 검증 로직 구현
- 웹소켓 세션 정보를 추가 및 제거하는 로직을 구현하여 연결된 사용자의 세션 추적

### 🧩 해결 방법
- 웹소켓 인증을 구현하기 위해 `JwtChannelInterceptor`를 구현하고 웹소켓 설정에 등록했습니다.
- 활성된 세션 연결 수를 추적할 수 있도록 `WebSocketSessionManager`를 도입했습니다.

### 🔍 리뷰 포인트
- `JwtChannelInterceptor`에서 JWT 토큰 검증 과정은 `JwtAuthenticationFilter`의 로직과 동일합니다.
- `WebSocketSessionManager`에서 로깅되는 정보가 충분한지 확인해주세요 ! 

