### PR TITLE
[#50] feat: 멤버 정보 조회 API 추가

### DIFF
--- a/src/main/java/org/dnd/timeet/member/controller/MemberController.java
+++ b/src/main/java/org/dnd/timeet/member/controller/MemberController.java
@@ -8,9 +8,11 @@ import org.dnd.timeet.common.utils.ApiUtils;
 import org.dnd.timeet.common.utils.ApiUtils.ApiResult;
 import org.dnd.timeet.member.application.MemberService;
 import org.dnd.timeet.member.domain.Member;
+import org.dnd.timeet.member.dto.MemberInfoResponse;
 import org.dnd.timeet.member.dto.MemberNicknameRequest;
 import org.dnd.timeet.member.dto.RegisterFcmRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +25,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+
+    @GetMapping("")
+    @Operation(summary = "사용자 정보 조회", description = "사용자 정보를 조회한다.")
+    public ResponseEntity<ApiResult<MemberInfoResponse>> getMemberInfo(@ReqUser Member member) {
+        return ResponseEntity.ok(ApiUtils.success(MemberInfoResponse.from(member)));
+    }
 
     @PatchMapping
     @Operation(summary = "fcmToken 등록", description = "fcmToken을 등록한다.")

--- a/src/main/java/org/dnd/timeet/member/dto/MemberInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/member/dto/MemberInfoResponse.java
@@ -12,12 +12,12 @@ public class MemberInfoResponse {
     @Schema(description = "사용자 id", nullable = false, example = "12")
     private long id;
     @Schema(description = "사용자 이름", nullable = false, example = "green12")
-    private String name;
+    private String nickname;
 
 
-    public MemberInfoResponse(long id, String name) {
+    public MemberInfoResponse(long id, String nickname) {
         this.id = id;
-        this.name = name;
+        this.nickname = nickname;
     }
 
     public static MemberInfoResponse from(Member member) {


### PR DESCRIPTION
## What is this PR? :mag:
- 멤버 정보 조회 API 추가
## Changes :memo:
- Member Controller: Access Token 이용한 API 추가
- Nickname 추가 API와의 통일성을 위한 MemberInfoResponse name -> nickname 필드명 수정
## Screenshot :camera:
Nan