### PR TITLE
[Feat/#59] 회의실 나가기 기능 및 안건 수정 기능 개발, 기획 변경으로 인한 코드 수정

### DIFF
--- a/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
+++ b/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
@@ -47,13 +47,6 @@ public class AgendaService {
                 Collections.singletonMap("MemberId", "Member is not a participant of the meeting"));
         }
 
-        // OrderNum 중복 검사
-        boolean isOrderNumExists = agendaRepository.existsByMeetingIdAndOrderNum(meetingId, createDto.getOrderNum());
-        if (isOrderNumExists) {
-            throw new BadRequestError(BadRequestError.ErrorCode.VALIDATION_FAILED,
-                Collections.singletonMap("OrderNum", "OrderNum already exists in the meeting"));
-        }
-
         Agenda agenda = createDto.toEntity(meeting);
         agenda = agendaRepository.save(agenda);
 
@@ -188,7 +181,7 @@ public class AgendaService {
         }
 
         agenda.update(patchRequest.getTitle(),
-            DurationUtils.convertLocalTimeToDuration(patchRequest.getAllocatedDuration()), patchRequest.getOrderNum());
+            DurationUtils.convertLocalTimeToDuration(patchRequest.getAllocatedDuration()));
 
         return new AgendaPatchResponse(agenda);
     }

--- a/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
+++ b/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
@@ -9,6 +9,8 @@ import org.dnd.timeet.agenda.dto.AgendaActionRequest;
 import org.dnd.timeet.agenda.dto.AgendaActionResponse;
 import org.dnd.timeet.agenda.dto.AgendaCreateRequest;
 import org.dnd.timeet.agenda.dto.AgendaInfoResponse;
+import org.dnd.timeet.agenda.dto.AgendaPatchRequest;
+import org.dnd.timeet.agenda.dto.AgendaPatchResponse;
 import org.dnd.timeet.common.security.CustomUserDetails;
 import org.dnd.timeet.common.utils.ApiUtils;
 import org.dnd.timeet.common.utils.ApiUtils.ApiResult;
@@ -19,6 +21,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -80,5 +83,16 @@ public class AgendaController {
         agendaService.cancelAgenda(meetingId, agendaId);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{meeting-id}/agendas/{agenda-id}")
+    @Operation(summary = "안건 수정", description = "지정된 ID에 해당하는 안건을 수정한다.")
+    public ResponseEntity<ApiResult<AgendaPatchResponse>> deleteAgenda(
+        @PathVariable("meeting-id") Long meetingId,
+        @PathVariable("agenda-id") Long agendaId,
+        @RequestBody AgendaPatchRequest patchRequest) {
+        AgendaPatchResponse response = agendaService.patchAgenda(meetingId, agendaId, patchRequest);
+
+        return ResponseEntity.ok(ApiUtils.success(response));
     }
 }

--- a/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
@@ -158,5 +158,11 @@ public class Agenda extends AuditableEntity {
         this.delete();
     }
 
+    public void update(String title, Duration allocatedDuration, Integer orderNum) {
+        this.title = title;
+        this.allocatedDuration = allocatedDuration;
+        this.orderNum = orderNum;
+    }
+
 }
 

--- a/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
@@ -158,10 +158,9 @@ public class Agenda extends AuditableEntity {
         this.delete();
     }
 
-    public void update(String title, Duration allocatedDuration, Integer orderNum) {
+    public void update(String title, Duration allocatedDuration) {
         this.title = title;
         this.allocatedDuration = allocatedDuration;
-        this.orderNum = orderNum;
     }
 
 }

--- a/src/main/java/org/dnd/timeet/agenda/domain/AgendaRepository.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/AgendaRepository.java
@@ -9,4 +9,9 @@ public interface AgendaRepository extends JpaRepository<Agenda, Long> {
     List<Agenda> findByMeetingId(Long meetingId);
 
     Optional<Agenda> findByIdAndMeetingId(Long agendaId, Long meetingId);
+
+    boolean existsByMeetingIdAndOrderNum(Long meetingId, Integer orderNum);
+
+    boolean existsByMeetingIdAndOrderNumAndStatus(Long meetingId, Integer orderNum, AgendaStatus status);
+
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaActionResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaActionResponse.java
@@ -24,7 +24,6 @@ public class AgendaActionResponse {
     private String currentDuration; // 현재까지 진행된 시간
     private String remainingDuration; // 남은 시간
 
-    private Integer orderNum;
     private String timestamp; // 수정 시간
 
     public AgendaActionResponse(Agenda agenda, Duration currentDuration, Duration remainingDuration) {
@@ -36,7 +35,6 @@ public class AgendaActionResponse {
         this.currentDuration = DurationUtils.formatDuration(currentDuration);
         this.remainingDuration = DurationUtils.formatDuration(remainingDuration);
 
-        this.orderNum = agenda.getOrderNum();
         this.timestamp = DateTimeUtils.formatLocalDateTime(LocalDateTime.now());
     }
 

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaCreateRequest.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaCreateRequest.java
@@ -32,17 +32,12 @@ public class AgendaCreateRequest {
     @Schema(description = "안건 소요 시간", example = "01:20:00")
     private LocalTime allocatedDuration;
 
-    @NotNull(message = "안건 순서는 반드시 입력되어야 합니다")
-    @Schema(description = "안건 순서", example = "1")
-    private Integer orderNum;
-
     public Agenda toEntity(Meeting meeting) {
         return Agenda.builder()
             .meeting(meeting)
             .title(this.title)
             .type(this.type.equals("AGENDA") ? AgendaType.AGENDA : AgendaType.BREAK)
             .allocatedDuration(DurationUtils.convertLocalTimeToDuration(this.allocatedDuration))
-            .orderNum(this.orderNum)
             .build();
     }
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaInfoResponse.java
@@ -54,9 +54,6 @@ public class AgendaInfoResponse {
         @Schema(description = "안건 상태", example = "INPROGRESS")
         private String status;
 
-        @Schema(description = "안건 순서 번호", example = "1")
-        private Integer orderNum;
-
         public AgendaResponse(Agenda agenda, Duration currentDuration, Duration remainingDuration) {
             this.agendaId = agenda.getId();
             this.title = agenda.getTitle();
@@ -64,7 +61,6 @@ public class AgendaInfoResponse {
             this.currentDuration = DurationUtils.formatDuration(currentDuration);
             this.remainingDuration = DurationUtils.formatDuration(remainingDuration);
             this.status = agenda.getStatus().name();
-            this.orderNum = agenda.getOrderNum();
         }
     }
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaInfoResponse.java
@@ -54,6 +54,9 @@ public class AgendaInfoResponse {
         @Schema(description = "안건 상태", example = "INPROGRESS")
         private String status;
 
+        @Schema(description = "안건 순서 번호", example = "1")
+        private Integer orderNum;
+
         public AgendaResponse(Agenda agenda, Duration currentDuration, Duration remainingDuration) {
             this.agendaId = agenda.getId();
             this.title = agenda.getTitle();
@@ -61,6 +64,7 @@ public class AgendaInfoResponse {
             this.currentDuration = DurationUtils.formatDuration(currentDuration);
             this.remainingDuration = DurationUtils.formatDuration(remainingDuration);
             this.status = agenda.getStatus().name();
+            this.orderNum = agenda.getOrderNum();
         }
     }
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaPatchRequest.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaPatchRequest.java
@@ -1,0 +1,25 @@
+package org.dnd.timeet.agenda.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Schema(description = "안건 수정 요청")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AgendaPatchRequest {
+
+    @Schema(description = "안건 제목", example = "브레인스토밍")
+    private String title;
+
+    @DateTimeFormat(pattern = "HH:mm:ss")
+    @Schema(description = "안건 소요 시간", example = "01:20:00")
+    private LocalTime allocatedDuration;
+
+    @Schema(description = "안건 순서", example = "1")
+    private Integer orderNum;
+}

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaPatchRequest.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaPatchRequest.java
@@ -19,7 +19,4 @@ public class AgendaPatchRequest {
     @DateTimeFormat(pattern = "HH:mm:ss")
     @Schema(description = "안건 소요 시간", example = "01:20:00")
     private LocalTime allocatedDuration;
-
-    @Schema(description = "안건 순서", example = "1")
-    private Integer orderNum;
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaPatchResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaPatchResponse.java
@@ -1,0 +1,35 @@
+package org.dnd.timeet.agenda.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.dnd.timeet.agenda.domain.Agenda;
+import org.dnd.timeet.common.utils.DurationUtils;
+
+@Schema(description = "안건 수정 응답")
+@Getter
+@Setter
+public class AgendaPatchResponse {
+
+    @Schema(description = "안건 id", example = "12")
+    private Long agendaId;
+
+    @Schema(description = "안건 제목", example = "안건 1")
+    private String title;
+
+    @NotNull(message = "안건 소요 시간은 반드시 입력되어야 합니다")
+    @Schema(description = "안건 소요 시간", example = "01:20:00")
+    private String allocatedDuration;
+
+    @Schema(description = "안건 순서", example = "1")
+    private Integer orderNum;
+
+    public AgendaPatchResponse(Agenda agenda) {
+        this.agendaId = agenda.getId();
+        this.title = agenda.getTitle();
+        this.allocatedDuration = DurationUtils.formatDuration(agenda.getAllocatedDuration());
+        this.orderNum = agenda.getOrderNum();
+    }
+
+}

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaPatchResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaPatchResponse.java
@@ -22,14 +22,10 @@ public class AgendaPatchResponse {
     @Schema(description = "안건 소요 시간", example = "01:20:00")
     private String allocatedDuration;
 
-    @Schema(description = "안건 순서", example = "1")
-    private Integer orderNum;
-
     public AgendaPatchResponse(Agenda agenda) {
         this.agendaId = agenda.getId();
         this.title = agenda.getTitle();
         this.allocatedDuration = DurationUtils.formatDuration(agenda.getAllocatedDuration());
-        this.orderNum = agenda.getOrderNum();
     }
 
 }

--- a/src/main/java/org/dnd/timeet/common/utils/DurationUtils.java
+++ b/src/main/java/org/dnd/timeet/common/utils/DurationUtils.java
@@ -12,8 +12,8 @@ public class DurationUtils {
      * @return Duration 객체
      */
     public static Duration convertLocalTimeToDuration(LocalTime time) {
-        int totalMinutes = time.getHour() * 60 + time.getMinute();
-        return Duration.ofMinutes(totalMinutes);
+        int totalSeconds = time.toSecondOfDay(); // 시, 분, 초를 모두 초 단위로 변환
+        return Duration.ofSeconds(totalSeconds); // 변환된 초를 바탕으로 Duration 생성
     }
 
     /**

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingAsyncService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingAsyncService.java
@@ -32,15 +32,4 @@ public class MeetingAsyncService {
             logger.error("Error starting scheduled meeting", e);
         }
     }
-
-    @Transactional
-    @Async // 비동기 작업 실행시 발생하는 에러 처리
-    public void endScheduledMeeting(Meeting meeting) {
-        try {
-            meeting.endMeeting();
-            meetingRepository.save(meeting);
-        } catch (Exception e) {
-            logger.error("Error starting scheduled meeting", e);
-        }
-    }
 }

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingAsyncService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingAsyncService.java
@@ -1,15 +1,10 @@
 package org.dnd.timeet.meeting.application;
 
-import java.util.Collections;
 import lombok.RequiredArgsConstructor;
-import org.dnd.timeet.common.exception.NotFoundError;
-import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.domain.MeetingRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,18 +13,18 @@ public class MeetingAsyncService {
     private final MeetingRepository meetingRepository;
     private final Logger logger = LoggerFactory.getLogger(MeetingAsyncService.class);
 
-    @Transactional
-    @Async // 비동기 작업 실행시 발생하는 에러 처리
-    public void startScheduledMeeting(Long meetingId) {
-        try {
-            Meeting meeting = meetingRepository.findById(meetingId)
-                .orElseThrow(() -> new NotFoundError(NotFoundError.ErrorCode.RESOURCE_NOT_FOUND,
-                    Collections.singletonMap("MeetingId", "Meeting not found")));
-
-            meeting.startMeeting();
-            meetingRepository.save(meeting);
-        } catch (Exception e) {
-            logger.error("Error starting scheduled meeting", e);
-        }
-    }
+//    @Transactional
+//    @Async // 비동기 작업 실행시 발생하는 에러 처리
+//    public void startScheduledMeeting(Long meetingId) {
+//        try {
+//            Meeting meeting = meetingRepository.findById(meetingId)
+//                .orElseThrow(() -> new NotFoundError(NotFoundError.ErrorCode.RESOURCE_NOT_FOUND,
+//                    Collections.singletonMap("MeetingId", "Meeting not found")));
+//
+//            meeting.startMeeting();
+//            meetingRepository.save(meeting);
+//        } catch (Exception e) {
+//            logger.error("Error starting scheduled meeting", e);
+//        }
+//    }
 }

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingScheduler.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingScheduler.java
@@ -36,19 +36,4 @@ public class MeetingScheduler {
             meetingAsyncService.startScheduledMeeting(meetingId), delay, TimeUnit.MILLISECONDS);
     }
 
-    @Scheduled(fixedRate = 60000) // 60000ms = 1분
-    public void scheduleMeetingEnd() {
-        List<Meeting> meetingsByStatusInProgress = meetingRepository.findMeetingsByStatusInProgress();
-
-        LocalDateTime now = LocalDateTime.now();
-
-        meetingsByStatusInProgress.forEach(meeting -> {
-            // 남은 시간이 0이거나 음수인 경우 회의를 종료
-            Duration remainingTime = meeting.calculateRemainingTime();
-            if (remainingTime.isZero() || remainingTime.isNegative()) {
-                meetingAsyncService.endScheduledMeeting(meeting);
-            }
-        });
-    }
-
 }

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingScheduler.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingScheduler.java
@@ -1,18 +1,9 @@
 package org.dnd.timeet.meeting.application;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
-import org.dnd.timeet.common.exception.BadRequestError;
-import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.domain.MeetingRepository;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @EnableScheduling
@@ -24,16 +15,16 @@ public class MeetingScheduler {
     private final ScheduledExecutorService scheduledExecutorService;
     private final MeetingRepository meetingRepository;
 
-    public void scheduleMeetingStart(Long meetingId, LocalDateTime startTime) {
-        long delay = ChronoUnit.MILLIS.between(LocalDateTime.now(), startTime);
-        if (delay < 0) {
-            throw new BadRequestError(BadRequestError.ErrorCode.VALIDATION_FAILED,
-                Collections.singletonMap("startTime", "startTime is past"));
-        }
-
-        // 스케줄러 생성
-        scheduledExecutorService.schedule(() ->
-            meetingAsyncService.startScheduledMeeting(meetingId), delay, TimeUnit.MILLISECONDS);
-    }
+//    public void scheduleMeetingStart(Long meetingId, LocalDateTime startTime) {
+//        long delay = ChronoUnit.MILLIS.between(LocalDateTime.now(), startTime);
+//        if (delay < 0) {
+//            throw new BadRequestError(BadRequestError.ErrorCode.VALIDATION_FAILED,
+//                Collections.singletonMap("startTime", "startTime is past"));
+//        }
+//
+//        // 스케줄러 생성
+//        scheduledExecutorService.schedule(() ->
+//            meetingAsyncService.startScheduledMeeting(meetingId), delay, TimeUnit.MILLISECONDS);
+//    }
 
 }

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
@@ -137,6 +137,12 @@ public class MeetingService {
             .orElseThrow(() -> new NotFoundError(NotFoundError.ErrorCode.RESOURCE_NOT_FOUND,
                 Collections.singletonMap("MeetingId", "Meeting not found")));
 
+        // 회의에 참가자가 없는 경우 빈 리스트 반환
+        if (meeting.getParticipants().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 참가자 목록을 Member 객체의 리스트로 변환하여 반환
         return meeting.getParticipants().stream()
             .map(Participant::getMember)
             .collect(Collectors.toList());

--- a/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
+++ b/src/main/java/org/dnd/timeet/meeting/application/MeetingService.java
@@ -37,7 +37,6 @@ public class MeetingService {
     private final MeetingRepository meetingRepository;
     private final ParticipantRepository participantRepository;
     private final AgendaRepository agendaRepository;
-    private final MeetingScheduler meetingScheduler;
     private final MemberRepository memberRepository;
 
 
@@ -47,9 +46,6 @@ public class MeetingService {
 
         Participant participant = new Participant(meeting, member);
         participantRepository.save(participant);
-
-        // 스케줄러를 통해 회의 시작 시간에 회의 시작
-        meetingScheduler.scheduleMeetingStart(meeting.getId(), meeting.getStartTime());
 
         return meeting;
     }

--- a/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
@@ -3,8 +3,6 @@ package org.dnd.timeet.meeting.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.dnd.timeet.common.security.CustomUserDetails;
 import org.dnd.timeet.common.security.annotation.ReqUser;
@@ -15,12 +13,11 @@ import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.meeting.dto.MeetingCreateRequest;
 import org.dnd.timeet.meeting.dto.MeetingCreateResponse;
 import org.dnd.timeet.meeting.dto.MeetingInfoResponse;
+import org.dnd.timeet.meeting.dto.MeetingMemberInfoResponse;
 import org.dnd.timeet.meeting.dto.MeetingRemainingTimeResponse;
 import org.dnd.timeet.meeting.dto.MeetingReportInfoResponse;
 import org.dnd.timeet.meeting.dto.MeetingReportResponse;
 import org.dnd.timeet.member.domain.Member;
-import org.dnd.timeet.member.dto.MemberInfoListResponse;
-import org.dnd.timeet.member.dto.MemberInfoResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -118,16 +115,11 @@ public class MeetingController {
 
     @GetMapping("/{meeting-id}/users")
     @Operation(summary = "회의 참가자 조회", description = "회의에 참가한 사용자를 조회한다.")
-    public ResponseEntity<ApiResult<MemberInfoListResponse>> getMeetingMembers(
+    public ResponseEntity<ApiResult<MeetingMemberInfoResponse>> getMeetingMembers(
         @PathVariable("meeting-id") Long meetingId) {
-        List<MemberInfoResponse> memberInfoList = meetingService.getMeetingMembers(meetingId)
-            .stream()
-            .map(MemberInfoResponse::from)
-            .collect(Collectors.toList());
+        MeetingMemberInfoResponse response = meetingService.getMeetingMembers(meetingId);
 
-        MemberInfoListResponse memberInfoListResponse = new MemberInfoListResponse(memberInfoList);
-
-        return ResponseEntity.ok(ApiUtils.success(memberInfoListResponse));
+        return ResponseEntity.ok(ApiUtils.success(response));
     }
 
     @DeleteMapping("/{meeting-id}/leave")

--- a/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
+++ b/src/main/java/org/dnd/timeet/meeting/controller/MeetingController.java
@@ -130,4 +130,11 @@ public class MeetingController {
         return ResponseEntity.ok(ApiUtils.success(memberInfoListResponse));
     }
 
+    @DeleteMapping("/{meeting-id}/leave")
+    @Operation(summary = "회의실 나가기", description = "지정된 id에 해당하는 회의에서 나간다.")
+    public ResponseEntity leaveMeeting(@PathVariable("meeting-id") Long meetingId, @ReqUser Member member) {
+        meetingService.leaveMeeting(meetingId, member.getId());
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
+++ b/src/main/java/org/dnd/timeet/meeting/domain/Meeting.java
@@ -22,6 +22,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.dnd.timeet.agenda.domain.Agenda;
 import org.dnd.timeet.common.domain.AuditableEntity;
 import org.dnd.timeet.common.exception.BadRequestError;
 import org.dnd.timeet.common.exception.BadRequestError.ErrorCode;
@@ -87,9 +88,12 @@ public class Meeting extends AuditableEntity {
         this.imgNum = imgNum;
     }
 
-
-    public void startMeeting() {
-        this.status = MeetingStatus.INPROGRESS;
+    public void updateStartTimeOnFirstAgendaStart(Agenda agenda) {
+        if (agenda.getOrderNum() == 1) {
+            // 회의 시작
+            this.startTime = LocalDateTime.now();
+            this.status = MeetingStatus.INPROGRESS;
+        }
     }
 
     // 회의 종료 버튼 누르거나 소요 시간이 끝날 경우

--- a/src/main/java/org/dnd/timeet/meeting/domain/MeetingRepository.java
+++ b/src/main/java/org/dnd/timeet/meeting/domain/MeetingRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
-    @Query("select m from Meeting m join fetch m.participants p join fetch p.member where m.id = :meetingId")
+    @Query("select m from Meeting m left join fetch m.participants p left join fetch p.member where m.id = :meetingId")
     Optional<Meeting> findByIdWithParticipantsAndMembers(@Param("meetingId") Long meetingId);
 
     @Query("SELECT m FROM Meeting m WHERE m.status = 'INPROGRESS'")

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.dnd.timeet.common.utils.DateTimeUtils;
 import org.dnd.timeet.common.utils.DurationUtils;
 import org.dnd.timeet.meeting.domain.Meeting;
 
@@ -28,7 +29,7 @@ public class MeetingInfoResponse {
     @Schema(description = "회의 방장 멤버 ID", example = "13")
     private Long hostMemberId;
 
-    @Schema(description = "회의 시작 일자", example = "2024-01-11T13:20")
+    @Schema(description = "회의 시작 일자", example = "2024-01-11T13:20:00")
     private String startTime;
 
     @Schema(description = "예상 소요시간", example = "03:00:00")
@@ -67,7 +68,7 @@ public class MeetingInfoResponse {
             .description(meeting.getDescription())
             .meetingStatus(meeting.getStatus().name())
             .hostMemberId(meeting.getHostMember() == null ? null : meeting.getHostMember().getId())
-            .startTime(meeting.getStartTime().toString())
+            .startTime(DateTimeUtils.formatLocalDateTime(meeting.getStartTime()))
             .totalEstimatedDuration(meeting.getTotalEstimatedDuration())
             .remainingTime(meeting.calculateRemainingTime())
             .actualTotalDuration(meeting.calculateCurrentDuration())

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingInfoResponse.java
@@ -66,7 +66,7 @@ public class MeetingInfoResponse {
             .title(meeting.getTitle())
             .description(meeting.getDescription())
             .meetingStatus(meeting.getStatus().name())
-            .hostMemberId(meeting.getHostMember().getId())
+            .hostMemberId(meeting.getHostMember() == null ? null : meeting.getHostMember().getId())
             .startTime(meeting.getStartTime().toString())
             .totalEstimatedDuration(meeting.getTotalEstimatedDuration())
             .remainingTime(meeting.calculateRemainingTime())

--- a/src/main/java/org/dnd/timeet/meeting/dto/MeetingMemberInfoResponse.java
+++ b/src/main/java/org/dnd/timeet/meeting/dto/MeetingMemberInfoResponse.java
@@ -1,0 +1,40 @@
+package org.dnd.timeet.meeting.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.dnd.timeet.member.domain.Member;
+
+@Schema(description = "회의 멤버 정보 응답")
+@Getter
+@Setter
+public class MeetingMemberInfoResponse {
+
+    MeetingMemberDetailResponse hostMember;
+    List<MeetingMemberDetailResponse> members;
+
+    public MeetingMemberInfoResponse(MeetingMemberDetailResponse hostMember,
+                                     List<MeetingMemberDetailResponse> members) {
+        this.hostMember = hostMember;
+        this.members = members;
+    }
+
+    @Getter
+    @Setter
+    public static class MeetingMemberDetailResponse {
+
+        @Schema(description = "사용자 id", nullable = false, example = "12")
+        private Long id;
+        @Schema(description = "사용자 이름", nullable = false, example = "green12")
+        private String nickname;
+
+
+        public MeetingMemberDetailResponse(Member member) {
+            this.id = member == null ? null : member.getId();
+            this.nickname = member == null ? null : member.getName();
+        }
+    }
+}
+
+

--- a/src/main/java/org/dnd/timeet/participant/domain/Participant.java
+++ b/src/main/java/org/dnd/timeet/participant/domain/Participant.java
@@ -4,25 +4,15 @@ package org.dnd.timeet.participant.domain;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.dnd.timeet.common.domain.AuditableEntity;
-import org.dnd.timeet.common.exception.BadRequestError;
 import org.dnd.timeet.meeting.domain.Meeting;
 import org.dnd.timeet.member.domain.Member;
 import org.hibernate.annotations.Where;
@@ -52,6 +42,17 @@ public class Participant extends AuditableEntity {
         member.getParticipations().add(this);
     }
 
+    public void removeParticipant() {
+        if (this.meeting != null) {
+            this.meeting.getParticipants().remove(this);
+            this.meeting = null;
+        }
+        if (this.member != null) {
+            this.member.getParticipations().remove(this);
+            this.member = null;
+        }
+        this.delete();
+    }
 
 }
 

--- a/src/main/java/org/dnd/timeet/participant/domain/ParticipantRepository.java
+++ b/src/main/java/org/dnd/timeet/participant/domain/ParticipantRepository.java
@@ -1,12 +1,11 @@
 package org.dnd.timeet.participant.domain;
 
 import java.util.Optional;
-import org.dnd.timeet.participant.domain.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
 
     Optional<Participant> findByMeetingIdAndMemberId(Long meetingId, Long memberId);
 
-//    Optional<Timer> findByUserId(Long id);
+    boolean existsByMeetingIdAndMemberId(Long meetingId, Long memberId);
 }


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #59 
- [x] #60 

resolved: #59  #60

### 🛠 개발 기능
- 회의 나가기 기능 개발
- 참가자가 없는 경우에도 조회가능하도록 개선
- 안건 수정 기능 개발

#### 기획 변경으로 인한 코드 수정
- 참가자 조회 API 개선
- 회의 스케줄링 조정: 기획 변경으로 인한 회의 시작 및 종료 스케줄링 기능 제거
- 회의 시작 프로세스 변경

### 🧩 해결 방법
- `미팅 나가기 기능`: 방장이 회의를 떠날 경우 회의에 남은 사람을 랜덤으로 방장으로 설정하도록 구현했습니다.
  방장이 아닐 경우에는 회의에 떠나는 작업만 수행됩니다.
- `안건 수정 기능` : 안건 이름과 할당 시간을 수정하는 기능을 구현했습니다.

- `참가자 조회 기능` 개선 : 참가자 조회 API에 `방장 정보`를 추가
- `회의 시작 프로세스` : 안건 시작시 자동으로 회의 시작되도록 기능 구현 

### 🔍 리뷰 포인트
- 프로젝트 발표 기간이 다가오고있네요..! 짧은 시간에 많은 부분을 수정하다보니 PR이 커졌어요 죄송합니다! ㅠㅠ
- 추가된 기능의 로직이 정확한지 확인 부탁드려요 !


<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
