### PR TITLE
[Feat#65] 안건 순서 수정 기능 개발

### DIFF
--- a/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
+++ b/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
@@ -157,6 +157,11 @@ public class AgendaService {
                 Collections.singletonMap("MeetingId", "Meeting not found")));
         List<Agenda> agendaList = agendaRepository.findByMeetingId(meetingId);
 
+        if (agendaList.size() != agendaIds.size()) {
+            throw new BadRequestError(BadRequestError.ErrorCode.VALIDATION_FAILED,
+                Collections.singletonMap("AgendaIds", "Agenda Ids size is not matched"));
+        }
+
         if (agendaList.size() != agendaIds.stream().distinct().count()) {
             throw new BadRequestError(BadRequestError.ErrorCode.VALIDATION_FAILED,
                 Collections.singletonMap("AgendaIds", "Agenda Ids are not unique"));

--- a/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
+++ b/src/main/java/org/dnd/timeet/agenda/application/AgendaService.java
@@ -3,6 +3,7 @@ package org.dnd.timeet.agenda.application;
 import java.time.Duration;
 import java.time.LocalTime;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.dnd.timeet.agenda.domain.Agenda;
@@ -33,6 +34,7 @@ public class AgendaService {
     private final AgendaRepository agendaRepository;
     private final ParticipantRepository participantRepository;
 
+    @Transactional
     public Long createAgenda(Long meetingId, AgendaCreateRequest createDto, Member member) {
         Meeting meeting = meetingRepository.findById(meetingId)
             .orElseThrow(() -> new NotFoundError(ErrorCode.RESOURCE_NOT_FOUND,
@@ -44,6 +46,8 @@ public class AgendaService {
                 Collections.singletonMap("MemberId", "Member is not a participant of the meeting")));
 
         Agenda agenda = createDto.toEntity(meeting);
+        List<Agenda> agendaList = agendaRepository.findByMeetingId(meetingId);
+        agenda.setOrderNum(agendaList.size() + 1);
         agenda = agendaRepository.save(agenda);
 
         // 회의 시간 추가
@@ -143,6 +147,31 @@ public class AgendaService {
             .orElseThrow(() -> new NotFoundError(ErrorCode.RESOURCE_NOT_FOUND,
                 Collections.singletonMap("MeetingId", "Meeting not found")));
         List<Agenda> agendaList = agendaRepository.findByMeetingId(meetingId);
+        agendaList.sort(Comparator.comparing(Agenda::getOrderNum));
+        return new AgendaInfoResponse(meeting, agendaList);
+    }
+
+    public AgendaInfoResponse changeAgendaOrder(Long meetingId, List<Long> agendaIds) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+            .orElseThrow(() -> new NotFoundError(ErrorCode.RESOURCE_NOT_FOUND,
+                Collections.singletonMap("MeetingId", "Meeting not found")));
+        List<Agenda> agendaList = agendaRepository.findByMeetingId(meetingId);
+
+        if (agendaList.size() != agendaIds.stream().distinct().count()) {
+            throw new BadRequestError(BadRequestError.ErrorCode.VALIDATION_FAILED,
+                Collections.singletonMap("AgendaIds", "Agenda Ids are not unique"));
+        }
+
+        for (int i = 0; i < agendaIds.size(); i++) {
+            Long agendaId = agendaIds.get(i);
+            Agenda agenda = agendaList.stream()
+                .filter(a -> a.getId().equals(agendaId))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundError(ErrorCode.RESOURCE_NOT_FOUND,
+                    Collections.singletonMap("AgendaId", "Agenda Id " + agendaId + " not found")));
+            agenda.setOrderNum(i + 1);
+        }
+        agendaList.sort(Comparator.comparing(Agenda::getOrderNum));
 
         return new AgendaInfoResponse(meeting, agendaList);
     }

--- a/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
+++ b/src/main/java/org/dnd/timeet/agenda/controller/AgendaController.java
@@ -9,6 +9,7 @@ import org.dnd.timeet.agenda.dto.AgendaActionRequest;
 import org.dnd.timeet.agenda.dto.AgendaActionResponse;
 import org.dnd.timeet.agenda.dto.AgendaCreateRequest;
 import org.dnd.timeet.agenda.dto.AgendaInfoResponse;
+import org.dnd.timeet.agenda.dto.AgendaOrderRequest;
 import org.dnd.timeet.common.security.CustomUserDetails;
 import org.dnd.timeet.common.utils.ApiUtils;
 import org.dnd.timeet.common.utils.ApiUtils.ApiResult;
@@ -19,6 +20,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -80,5 +82,15 @@ public class AgendaController {
         agendaService.cancelAgenda(meetingId, agendaId);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{meeting-id}/agendas/order")
+    @Operation(summary = "안건 순서 변경", description = "안건의 순서를 변경한다.")
+    public ResponseEntity<ApiResult<AgendaInfoResponse>> changeAgendaOrder(
+        @PathVariable("meeting-id") Long meetingId,
+        @RequestBody @Valid AgendaOrderRequest agendaOrderRequest) {
+        AgendaInfoResponse agendaInfoResponse = agendaService.changeAgendaOrder(meetingId,
+            agendaOrderRequest.getAgendaIds());
+        return ResponseEntity.ok(ApiUtils.success(agendaInfoResponse));
     }
 }

--- a/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
+++ b/src/main/java/org/dnd/timeet/agenda/domain/Agenda.java
@@ -75,6 +75,9 @@ public class Agenda extends AuditableEntity {
         this.orderNum = orderNum;
     }
 
+    public void setOrderNum(Integer orderNum) {
+        this.orderNum = orderNum;
+    }
 
     public void start() {
         validateTransition(AgendaStatus.PENDING);

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaActionResponse.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaActionResponse.java
@@ -35,8 +35,7 @@ public class AgendaActionResponse {
 
         this.currentDuration = DurationUtils.formatDuration(currentDuration);
         this.remainingDuration = DurationUtils.formatDuration(remainingDuration);
-
-        this.orderNum = agenda.getOrderNum();
+        
         this.timestamp = DateTimeUtils.formatLocalDateTime(LocalDateTime.now());
     }
 

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaCreateRequest.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaCreateRequest.java
@@ -32,17 +32,12 @@ public class AgendaCreateRequest {
     @Schema(description = "안건 소요 시간", example = "01:20:00")
     private LocalTime allocatedDuration;
 
-    @NotNull(message = "안건 순서는 반드시 입력되어야 합니다")
-    @Schema(description = "안건 순서", example = "1")
-    private Integer orderNum;
-
     public Agenda toEntity(Meeting meeting) {
         return Agenda.builder()
             .meeting(meeting)
             .title(this.title)
             .type(this.type.equals("AGENDA") ? AgendaType.AGENDA : AgendaType.BREAK)
             .allocatedDuration(DurationUtils.convertLocalTimeToDuration(this.allocatedDuration))
-            .orderNum(this.orderNum)
             .build();
     }
 }

--- a/src/main/java/org/dnd/timeet/agenda/dto/AgendaOrderRequest.java
+++ b/src/main/java/org/dnd/timeet/agenda/dto/AgendaOrderRequest.java
@@ -1,0 +1,18 @@
+package org.dnd.timeet.agenda.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Schema(description = "안건 순서 변경 요청")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AgendaOrderRequest {
+
+    @Schema(description = "안건 ID 리스트", example = "[2,1,3]")
+    private List<Long> agendaIds;
+
+}


### PR DESCRIPTION
### 🔗 Linked Issue
- [x] #65 

resolved: #65

### 🛠 개발 기능
- 안건 순서를 수정할 수 있도록 하였습니다.

### 🧩 해결 방법
- 안건 생성시 (안건 개수 + 1)인 orderNum을 부여받습니다.
- 안건 조회시 orderNum에 따라 정렬됩니다.
- 안건 순서 수정 컨트롤러를 통해 요청으로 들어온 agendaIds에 맞게 orderNum이 재배치됩니다.

### 🔍 리뷰 포인트
- 안건 순서 수정시 빠진 예외 처리가 없을지 확인부탁드려요!



<br>

---
### 📋 Code Review Priority Guideline
- 🚨 **P1: Request Change**
  - **필수 반영**: 꼭 반영해주시고, 적극적으로 고려해주세요 (수용 혹은 토론).
- 💬 **P2: Comment**
  - **권장 반영**: 웬만하면 반영해주세요.
- 👍 **P3: Approve**
  - **선택 반영**: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다.
